### PR TITLE
docs(agents): expand Codex auto-resolve to verification + Japanese PR body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -630,13 +630,13 @@ fi
 
 リポ別の標準コマンド (Codex は AGENTS.md / CLAUDE.md > package.json scripts > 慣例 の順で検出):
 
-| 言語 / 環境     | build               | lint                    | typecheck           | test                |
-| --------------- | ------------------- | ----------------------- | ------------------- | ------------------- |
-| Node (npm/pnpm) | `npm run build`     | `npm run lint`          | `npm run typecheck` | `npm test`          |
-| Python (uv)     | `uv build` (該当時) | `uv run ruff check`     | `uv run mypy`       | `uv run pytest`     |
-| Python (poetry) | -                   | `poetry run ruff check` | `poetry run mypy`   | `poetry run pytest` |
-| Rust            | `cargo build`       | `cargo clippy`          | -                   | `cargo test`        |
-| Go              | `go build ./...`    | `golangci-lint run`     | `go vet ./...`      | `go test ./...`     |
+| 言語 / 環境     | build               | lint                      | format                     | typecheck           | test                |
+| --------------- | ------------------- | ------------------------- | -------------------------- | ------------------- | ------------------- |
+| Node (npm/pnpm) | `npm run build`     | `npm run lint`            | `npm run format`           | `npm run typecheck` | `npm test`          |
+| Python (uv)     | `uv build` (該当時) | `uv run ruff check .`     | `uv run ruff format .`     | `uv run mypy .`     | `uv run pytest`     |
+| Python (poetry) | -                   | `poetry run ruff check .` | `poetry run ruff format .` | `poetry run mypy .` | `poetry run pytest` |
+| Rust            | `cargo build`       | `cargo clippy`            | `cargo fmt`                | -                   | `cargo test`        |
+| Go              | `go build ./...`    | `golangci-lint run`       | `go fmt ./...`             | `go vet ./...`      | `go test ./...`     |
 
 存在しないコマンドは省略（埋め草で書かない）。リポ独自のスクリプト (`make ci` 等) があればそれを優先する。
 
@@ -696,13 +696,16 @@ Closes #{issue_number}
 
 ## 動作確認 (Verification)
 
-| 項目                       | コマンド            | 結果        |
-| -------------------------- | ------------------- | ----------- |
-| Build                      | `npm run build`     | ✅ pass     |
-| Lint                       | `npm run lint`      | ✅ 0 errors |
-| Typecheck                  | `npm run typecheck` | ✅ pass     |
-| Unit test                  | `npm test`          | ✅ N passed |
-| (該当時) E2E / Integration | `...`               | ✅ pass     |
+| 項目                       | コマンド              | 結果        |
+| -------------------------- | --------------------- | ----------- |
+| Build                      | `{build_command}`     | ✅ pass     |
+| Lint                       | `{lint_command}`      | ✅ 0 errors |
+| Format                     | `{format_command}`    | ✅ pass     |
+| Typecheck                  | `{typecheck_command}` | ✅ pass     |
+| Unit test                  | `{test_command}`      | ✅ N passed |
+| (該当時) E2E / Integration | `{e2e_command}`       | ✅ pass     |
+
+> コマンド欄は前章「検証コマンドの自動検出」表からリポの言語に合わせて埋める。該当しない行は省略。
 
 実行ログ要約: {自己修正で直したエラー、許容した warning、未対応の理由など。なければ「初回成功」}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,15 @@ Every session:
 - Commit to this workspace (reports/, knowledge/, monitoring/ のみ)
 - Read any monitored repo via gh CLI
 - Create **draft** Pull Requests via `codex exec` (see Auto-Resolve section)
+- Codex auto-resolve 内で監視リポに対して以下を実行:
+  - 自己修正コミット (最大3回、検証ループの一部として)
+  - draft PR の本文を "PR Description Standards" に従って更新
+  - issue-tracker.jsonl への verification 結果記録
+
+**Interactive (Ken と対話中) のみ許可:**
+
+- 本ワークスペースの `.gitignore` / ドキュメント / 構成ファイルの修正
+- 監視リポへの ready PR 化提案 (実行は Ken の承認後)
 
 **Never modify these files:**
 
@@ -205,13 +214,18 @@ PM が作成した Issue の事後検証を行い、次の Issue 作成品質を
 
 ### Quality Score 判定
 
-| Score | 条件                                                                   | 意味                          |
-| ----- | ---------------------------------------------------------------------- | ----------------------------- |
-| A     | PR マージ済み + Issue 本文の修正なし                                   | Issue の品質が十分だった      |
-| B     | PR マージ済み + Issue 本文に軽微な修正あり                             | おおむね良いが改善余地あり    |
-| C     | PR マージ済み + Issue 本文に大幅修正 or resolve-issue が途中で質問した | 情報不足だった                |
-| D     | Issue close (won't fix / duplicate / invalid)                          | 不要な Issue を作ってしまった |
-| -     | Open (未着手)                                                          | 評価待ち                      |
+Issue 単体の品質と、Codex auto-resolve が生成した PR の品質の **両方** を見る。
+
+| Score | 条件                                                                                                      | 意味                       |
+| ----- | --------------------------------------------------------------------------------------------------------- | -------------------------- |
+| A     | PR マージ済み + Issue 本文修正なし + 検証テーブル全 ✅ + レビュー指摘なし or 軽微                         | Issue / PR 共に十分な品質  |
+| B     | PR マージ済み + Issue 本文軽微修正 or PR description のセクション欠落 or 修正コミットあり                 | おおむね良いが改善余地あり |
+| C     | PR マージ済み + Issue 本文大幅修正 / resolve-issue が途中で質問した / 検証 ❌ を残したまま ready 化された | 情報不足 or 検証不足       |
+| D     | Issue close (won't fix / duplicate / invalid) or PR close (作り直し)                                      | 不要な Issue / PR を作った |
+| -     | Open (未着手)                                                                                             | 評価待ち                   |
+
+PR description が "PR Description Standards" のテンプレートに準拠しているか、検証テーブルが
+正直に書かれているか (失敗を隠していないか) を C の判定基準に含める。
 
 ### 検証タイミング
 
@@ -559,6 +573,8 @@ Follow knowledge/STRATEGY.md:
 ## Auto-Resolve via Codex
 
 Issue 作成後、Codex CLI の `resolve-issue` スキルを使って自動的に draft PR を作成する。
+Codex には「コードを書く」だけでなく「自分で検証してPR本文に結果を書き込む」ところまでをループさせる。
+Ken の手動検証コストを最小化するのが目的。
 
 ### ローカルリポパス
 
@@ -575,10 +591,33 @@ cd /Users/ken/Developer/private/{repo_name}
 git fetch origin
 git checkout main && git pull origin main
 
-# 2. Codex で Issue を解決（draft PR を作成）
+# 2. Codex で Issue を解決し、検証 + PR本文整形まで完走させる
+#    プロンプトは "Codex Prompting Guidelines" 章の標準テンプレを使う
 codex exec -C /Users/ken/Developer/private/{repo_name} \
   --full-auto \
-  "/resolve-issue #{issue_number}"
+  "$(cat <<'EOF'
+/resolve-issue #{issue_number}
+
+実装後は必ず以下のループを完走させてから draft PR を作成してください。
+
+【検証 (Verification)】
+1. プロジェクト標準のチェックを順に実行する。コマンドは package.json / pyproject.toml /
+   Makefile / Taskfile などから検出する。該当しないものはスキップ。
+   - build, lint, format, typecheck, unit test, (該当時) integration / e2e
+2. 失敗があれば最大3回まで自己修正コミットを積んで再実行する。
+3. それでも残った失敗は隠さず PR 本文に ❌ で明示する。
+
+【PR 本文】
+- workspace の AGENTS.md "PR Description Standards" に従い **日本語** で記述する。
+- 動作確認テーブル、受け入れ条件のチェック、影響範囲、レビュー観点を必ず埋める。
+- 推測を断定として書かない。確認できていないものは「未検証」と書く。
+
+【ルール】
+- ファイル削除や破壊的変更が必要なら PR 本文の "影響範囲 / リスク" に明記する。
+- AGENTS.md / scripts/ / config/repos.yaml は変更しない（workspace 側のガード）。
+- コミットメッセージ・ブランチ名・PRタイトルは英語、PR本文は日本語。
+EOF
+)"
 
 # 3. PR が作成されたら gh で draft に変換（resolve-issue が通常PRを作る場合）
 pr_number=$(gh pr list -R {owner}/{name} --head "$(git branch --show-current)" --json number --jq '.[0].number')
@@ -587,11 +626,26 @@ if [ -n "$pr_number" ]; then
 fi
 ```
 
+### 検証コマンドの自動検出
+
+リポ別の標準コマンド (Codex は AGENTS.md / CLAUDE.md > package.json scripts > 慣例 の順で検出):
+
+| 言語 / 環境     | build               | lint                    | typecheck           | test                |
+| --------------- | ------------------- | ----------------------- | ------------------- | ------------------- |
+| Node (npm/pnpm) | `npm run build`     | `npm run lint`          | `npm run typecheck` | `npm test`          |
+| Python (uv)     | `uv build` (該当時) | `uv run ruff check`     | `uv run mypy`       | `uv run pytest`     |
+| Python (poetry) | -                   | `poetry run ruff check` | `poetry run mypy`   | `poetry run pytest` |
+| Rust            | `cargo build`       | `cargo clippy`          | -                   | `cargo test`        |
+| Go              | `go build ./...`    | `golangci-lint run`     | `go vet ./...`      | `go test ./...`     |
+
+存在しないコマンドは省略（埋め草で書かない）。リポ独自のスクリプト (`make ci` 等) があればそれを優先する。
+
 ### 制約
 
 - **1 Issue ずつ逐次処理**（並列実行しない）
 - codex が AGENTS.md を見つけられない場合、CLAUDE.md をプロジェクトコンテキストとして使用する（codex は自動的に読む）
 - codex exec のタイムアウト: 15分（`--timeout 900` 相当）
+- 自己修正の試行は **最大3回**。それを超えたら諦めて ❌ 明示で draft PR にする (失敗を隠さない)
 - 失敗した場合: issue-tracker.jsonl に `"auto_resolve": "failed"` を記録し、次の Issue に進む
 - PR 作成後: issue-tracker.jsonl に `"auto_resolve": "draft_pr_created", "pr": N` を記録
 
@@ -606,11 +660,158 @@ fi
   "status": "open",
   "auto_resolve": "draft_pr_created",
   "pr": 51,
-  "codex_duration_sec": 342
+  "codex_duration_sec": 342,
+  "verification": {
+    "build": "pass",
+    "lint": "pass",
+    "typecheck": "pass",
+    "test": "pass",
+    "self_fix_attempts": 0
+  }
 }
 ```
 
 `auto_resolve` の値: `"pending"` | `"in_progress"` | `"draft_pr_created"` | `"failed"` | `"skipped"`
+`verification` 各項目: `"pass"` | `"fail"` | `"warn"` | `"skipped"` | `"n/a"`
+
+## PR Description Standards (Codex Auto-PR)
+
+Codex が draft PR を生成するときは、以下の構造を **日本語** で必ず含める。
+人間レビュアー (Ken) が PR タブの最初の画面で「マージしてよいか」「どこを重点的に見るか」を即判断できる粒度を目指す。
+
+### テンプレート
+
+```markdown
+## 概要
+
+{1〜3文で「何を」「なぜ」変えたか。Issue の Problem/Why を要約}
+
+Closes #{issue_number}
+
+## 変更内容
+
+- {ファイル / モジュール単位の主要変更を箇条書き}
+- {追加・修正・削除を分けて書く}
+- {自動生成ファイル (lockfile, snapshot 等) は別行で「自動更新」と明示}
+
+## 動作確認 (Verification)
+
+| 項目                       | コマンド            | 結果        |
+| -------------------------- | ------------------- | ----------- |
+| Build                      | `npm run build`     | ✅ pass     |
+| Lint                       | `npm run lint`      | ✅ 0 errors |
+| Typecheck                  | `npm run typecheck` | ✅ pass     |
+| Unit test                  | `npm test`          | ✅ N passed |
+| (該当時) E2E / Integration | `...`               | ✅ pass     |
+
+実行ログ要約: {自己修正で直したエラー、許容した warning、未対応の理由など。なければ「初回成功」}
+
+## 受け入れ条件 (Acceptance Criteria)
+
+Issue の Acceptance Criteria を一行ずつ転記し、満たした方法を添える:
+
+- [x] {条件1} → {検証方法 / 該当ファイル}
+- [x] {条件2} → {...}
+- [ ] {未達があれば理由を1文で}
+
+## スコープ外 (Non-goals)
+
+- {このPRで対応していないこと}
+- {follow-up Issue が必要なら #N で参照}
+
+## 影響範囲 / リスク
+
+- 影響API: {変更した公開 API。なければ「なし（内部のみ）」}
+- 互換性: {破壊的変更の有無、移行手順}
+- ロールバック: {差し戻し手順。`git revert` で十分かどうか}
+
+## レビュー観点 (Review Focus)
+
+レビュアーに重点的に見てほしい箇所を1〜3点。多くしすぎない:
+
+- `{path/to/file}:L{N}` — {観点を1文で}
+- {...}
+
+## スクリーンショット / 出力例
+
+UI / CLI / レポート出力に変化がある場合のみ画像 or コードブロックを貼る。
+
+---
+
+Generated by Codex auto-resolve / Reviewed by knishioka-pm
+```
+
+### セクション必須度
+
+| セクション         | 必須                                  |
+| ------------------ | ------------------------------------- |
+| 概要 + Closes      | 常に必須                              |
+| 変更内容           | 常に必須                              |
+| 動作確認           | 常に必須 (該当しない項目は行ごと省略) |
+| 受け入れ条件       | 常に必須                              |
+| スコープ外         | 常に必須 (空でも「なし」と明記)       |
+| 影響範囲 / リスク  | 常に必須                              |
+| レビュー観点       | 常に必須 (1点でも書く)                |
+| スクリーンショット | UI / 出力変化があるときのみ           |
+
+### 書き方のルール
+
+- **隠さない**: 失敗・未検証・warning は ❌ / ⚠️ / 「未検証」で明示する。Codex が「直せなかった」状態でPR本文を成功で塗らない。
+- **推測を断定にしない**: コードを読んだだけで実行していないチェックは「コード上では満たしているが未実行」と書く。
+- **言語**: 本文は日本語。コマンド名・ファイルパス・コミットメッセージ・PRタイトル・ブランチ名は英語のまま。
+- **量**: 各セクション 3〜7 行を目安。長くなるなら follow-up Issue に切り出す。
+- **再現性**: コマンドはコピペで動く形で書く (`./scripts/x.sh` のようにリポ root 起点)。
+- **レビュー観点**: 「全体的に確認お願いします」のような中身のない記述は禁止。
+
+## Codex Prompting Guidelines
+
+Codex に作業を投げるときの共通方針 (web 調査ベース)。Issue 自動解決 / 修正依頼 / レビュー
+依頼すべてに適用する。
+
+### 原則
+
+1. **Goals + Constraints で書く。step-by-step で railroad しない。**
+   - 良い例: 「全テスト green にしてから draft PR を出す。3回失敗したら ❌ で記録」
+   - 悪い例: 「まず npm install、次に npm test、次に...」(リポ毎の差を吸収できない)
+2. **検証ループを必ず含める。**
+   - "実装 → 検証 → 直す → 再検証" を 1 プロンプトで完走させる。
+   - 検証コマンドはリポ側の AGENTS.md / CLAUDE.md / package.json に書いておけば Codex が拾う。
+3. **「good」の定義を明示する。**
+   - 何をもって完了かを書く: 「全 Acceptance Criteria が [x]、CI 全 green、PR description が
+     workspace AGENTS.md の "PR Description Standards" に準拠」
+4. **失敗は隠さず明示。**
+   - ❌ や「未検証」を許容することで、Codex に成功を捏造させない。
+5. **AGENTS.md レイヤーを活用。**
+   - workspace AGENTS.md (このファイル) = ポリシー / PR フォーマット / 配信ルール
+   - 各リポ AGENTS.md / CLAUDE.md = 検証コマンド / アーキ概要 / コーディング規約
+   - Codex は両方を読むので、ポリシーと技術詳細を分けて書く。
+
+### 標準プロンプト構造
+
+```
+{タスク要約 (1行)}
+
+【目標】
+- {達成すべきこと}
+
+【制約】
+- {触ってはいけないファイル / 守るべき互換性}
+
+【検証】
+- {成功の定義となるコマンド}
+
+【出力】
+- {何を残すか: コミット / draft PR / レポート / コメント}
+```
+
+このテンプレを `codex exec` のプロンプトに埋め込む。
+
+### Anti-patterns (避けるべき書き方)
+
+- 「いい感じに直して」 → "good" の定義がないので Codex がレビュー指摘の出やすい実装をする
+- 「テストは書かなくていい」 → 検証ループが回らないので品質が保証できない
+- 手順を逐次プロンプトで送る → context が分断され Codex が判断できない
+- リポ側 AGENTS.md と矛盾する指示 → workspace 側を上書きしないと Codex が混乱する
 
 ## Cron Jobs
 


### PR DESCRIPTION
## Summary

Codex auto-resolve に **検証ループ + 日本語 PR description テンプレート** を組み込み、AGENTS.md にポリシーとして固定する PR。

これまで Codex は「Issue を読んで実装してdraft PRを作る」までしかやっておらず、**動作確認・PR本文の質**は完全に Ken の手動レビュー任せだった。Codex CLI / AGENTS.md のベストプラクティス ([OpenAI Codex docs](https://developers.openai.com/codex/learn/best-practices), [Codex Prompting Guide](https://developers.openai.com/cookbook/examples/gpt-5/codex_prompting_guide)) を踏まえ、検証と本文生成まで Codex に押し戻すことでレビューコストを下げる。

## 主な変更 (AGENTS.md)

- **Auto-Resolve via Codex**: 標準プロンプトに検証ループ (build/lint/typecheck/test) + 自己修正 最大3回 + 失敗を隠さない方針を明記。検証コマンド自動検出表 (Node/Python/Rust/Go) を追加
- **PR Description Standards (Codex Auto-PR)** 新設: 日本語 PR 本文テンプレートを定義。概要 / 変更内容 / 動作確認テーブル / 受け入れ条件 / スコープ外 / 影響範囲 / レビュー観点 を必須化、失敗は ❌/⚠️/未検証 で明示するルール
- **Codex Prompting Guidelines** 新設: goals + constraints で書く、step-by-step で railroad しない、good の定義を明示、AGENTS.md レイヤー活用
- **Issue Retrospective Quality Score**: PR description のテンプレ準拠と検証テーブルの正直さ (失敗を隠していないか) を判定基準に追加
- **Safety Rules**: autonomous で許可する Codex 行動 (自己修正コミット 3 回まで、PR 本文更新、verification 結果記録) と interactive のみ許可する範囲を分離
- **issue-tracker.jsonl** に verification フィールド (build/lint/typecheck/test/self_fix_attempts) を追加

## レビューポイント

- \`AGENTS.md:573-650\` 周辺の Codex プロンプトテンプレが各リポで使う検証コマンドと整合するか (Node リポは npm script、Python リポは uv/poetry を想定)
- \`PR Description Standards\` テンプレが Ken のレビュー粒度に合うか (項目が多すぎないか / 足りないか)
- Safety Rules の interactive / autonomous 区切りが PR #1 で議論された境界と整合するか

## Test plan

- [x] markdown としてセクション階層が壊れていないか目視確認
- [ ] 次回 focus-task (cron) で更新後の AGENTS.md を Codex が読み、検証ループ + 日本語 PR 本文を実行することを確認
- [ ] 1サイクル後、生成された PR の本文が "PR Description Standards" に準拠しているか目視レビュー
- [ ] issue-tracker.jsonl に verification フィールドが書き込まれているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)