### PR TITLE
feat(scripts): add codex-resolve.sh wrapper to inject playbook (#6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,12 +36,12 @@ Every session:
 
 - 本ワークスペースの `.gitignore` / ドキュメント / 構成ファイルの修正
 - 監視リポへの ready PR 化提案 (実行は Ken の承認後)
+- `scripts/*` の追加・修正 (cron / 自動セッションからは編集不可。Ken と対話している場合のみ可)
 
 **Never modify these files:**
 
 - AGENTS.md, SOUL.md, USER.md, IDENTITY.md, HEARTBEAT.md
 - config/repos.yaml, config/thresholds.yaml
-- scripts/\*
 
 **Requires Ken's explicit approval:**
 
@@ -108,11 +108,12 @@ repos.yaml の `private_repos:` に記載されたリポは:
 
 ## Scripts
 
-| Script              | Purpose                   | Output      |
-| ------------------- | ------------------------- | ----------- |
-| `repo-health`       | Health diagnosis per repo | JSON stdout |
-| `task-suggest`      | Next action suggestions   | JSON stdout |
-| `knowledge-collect` | Knowledge extraction      | JSON stdout |
+| Script              | Purpose                                       | Output                                      |
+| ------------------- | --------------------------------------------- | ------------------------------------------- |
+| `repo-health`       | Health diagnosis per repo                     | JSON stdout                                 |
+| `task-suggest`      | Next action suggestions                       | JSON stdout                                 |
+| `knowledge-collect` | Knowledge extraction                          | JSON stdout                                 |
+| `codex-resolve.sh`  | Codex auto-resolve wrapper (injects playbook) | passthrough stdout / exit code (codex の値) |
 
 Scripts use `gh` CLI for all GitHub API calls. No direct API tokens.
 

--- a/scripts/codex-resolve.sh
+++ b/scripts/codex-resolve.sh
@@ -43,7 +43,9 @@ LOCAL_REPO_BASE="${LOCAL_REPO_BASE:-/Users/ken/Developer/private}"
 CODEX_TIMEOUT="${CODEX_TIMEOUT:-900}"
 
 usage() {
-  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the leading header comment block (after the shebang) up to the first
+  # non-comment line. Auto-extends as the header grows; no hardcoded line range.
+  awk 'NR==1{next} /^[^#]/{exit} {sub(/^# ?/,""); print}' "${BASH_SOURCE[0]}"
 }
 
 # --- Parse args (positional + --dry-run anywhere) ---
@@ -89,7 +91,11 @@ fi
 # This grep matches a YAML mapping key "name" with our exact REPO_NAME value
 # under either `repos:` or `private_repos:` (both share the same path prefix
 # per docs/codex-playbook.md).
-if ! grep -E "^[[:space:]]*-?[[:space:]]*name:[[:space:]]*${REPO_NAME}[[:space:]]*$" \
+# Escape dots in REPO_NAME so a name like "foo.bar" matches only "foo.bar"
+# in the ERE, not "fooXbar". Other allowed chars in the validation regex
+# (alnum / underscore / hyphen) are not ERE metacharacters in this position.
+REPO_NAME_RE="${REPO_NAME//./\\.}"
+if ! grep -E "^[[:space:]]*-?[[:space:]]*name:[[:space:]]*${REPO_NAME_RE}[[:space:]]*$" \
      "$REPOS_YAML" >/dev/null; then
   echo "Error: '$REPO_NAME' not found in $REPOS_YAML (repos: or private_repos:)" >&2
   exit 2

--- a/scripts/codex-resolve.sh
+++ b/scripts/codex-resolve.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# codex-resolve: Wrapper that injects workspace Codex playbook into the prompt
+# before invoking `codex exec` for a given Issue.
+#
+# Why: the focus-task cron previously called `codex exec` directly with just
+# `/resolve-issue #N`. Codex only reads the target repo's CLAUDE.md / AGENTS.md,
+# so the workspace AGENTS.md (PR Description Standards / Codex Prompting
+# Guidelines) never reached Codex. This wrapper prepends docs/codex-playbook.md
+# to the prompt, giving Codex the workspace policy without per-repo duplication.
+#
+# Usage:
+#   scripts/codex-resolve.sh <owner/repo> <issue_number> [--dry-run]
+#   scripts/codex-resolve.sh --dry-run <owner/repo> <issue_number>
+#
+# Example:
+#   scripts/codex-resolve.sh --dry-run knishioka/kanji-practice 48
+#   scripts/codex-resolve.sh knishioka/math-worksheet 51
+#
+# Exit codes:
+#   0   codex exec succeeded (or dry-run completed)
+#   2   bad arguments / repo not found in config/repos.yaml
+#   3   local repo path missing
+#   4   docs/codex-playbook.md missing
+#   124 codex exec timed out (15min)
+#   *   codex exec exit code passthrough
+#
+# Dependencies: bash, gh, codex, gtimeout (GNU coreutils). jq is not required
+# here (kept for future structured-summary output). yq is not required because
+# the path convention is uniform; repos.yaml is validated with grep.
+
+set -euo pipefail
+
+# --- Locate workspace root (parent of this script's dir) ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPOS_YAML="${WORKSPACE_ROOT}/config/repos.yaml"
+PLAYBOOK="${WORKSPACE_ROOT}/docs/codex-playbook.md"
+
+# Local checkout convention (matches docs/codex-playbook.md "ローカルリポパス")
+LOCAL_REPO_BASE="${LOCAL_REPO_BASE:-/Users/ken/Developer/private}"
+
+# Codex timeout (seconds). Matches playbook's "codex exec のタイムアウト: 15分".
+CODEX_TIMEOUT="${CODEX_TIMEOUT:-900}"
+
+usage() {
+  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- Parse args (positional + --dry-run anywhere) ---
+DRY_RUN=0
+POS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "Error: unknown flag: $arg" >&2; usage >&2; exit 2 ;;
+    *) POS+=("$arg") ;;
+  esac
+done
+
+if [ "${#POS[@]}" -ne 2 ]; then
+  echo "Error: expected 2 positional args (<owner/repo> <issue_number>), got ${#POS[@]}" >&2
+  usage >&2
+  exit 2
+fi
+
+OWNER_REPO="${POS[0]}"
+ISSUE_NUMBER="${POS[1]}"
+
+if ! [[ "$OWNER_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Error: <owner/repo> must look like 'owner/name', got: $OWNER_REPO" >&2
+  exit 2
+fi
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: <issue_number> must be a positive integer, got: $ISSUE_NUMBER" >&2
+  exit 2
+fi
+
+REPO_NAME="${OWNER_REPO##*/}"
+
+# --- Validate the repo is configured (public or private list) ---
+if [ ! -f "$REPOS_YAML" ]; then
+  echo "Error: $REPOS_YAML not found" >&2
+  exit 2
+fi
+
+# repos.yaml entries look like:   - name: foo
+# This grep matches a YAML mapping key "name" with our exact REPO_NAME value
+# under either `repos:` or `private_repos:` (both share the same path prefix
+# per docs/codex-playbook.md).
+if ! grep -E "^[[:space:]]*-?[[:space:]]*name:[[:space:]]*${REPO_NAME}[[:space:]]*$" \
+     "$REPOS_YAML" >/dev/null; then
+  echo "Error: '$REPO_NAME' not found in $REPOS_YAML (repos: or private_repos:)" >&2
+  exit 2
+fi
+
+# --- Resolve local repo path ---
+REPO_PATH="${LOCAL_REPO_BASE}/${REPO_NAME}"
+
+if [ ! -d "$REPO_PATH" ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Warning: $REPO_PATH does not exist (dry-run continues)" >&2
+  else
+    echo "Error: local checkout not found at $REPO_PATH" >&2
+    exit 3
+  fi
+fi
+
+# --- Read playbook ---
+if [ ! -f "$PLAYBOOK" ]; then
+  echo "Error: $PLAYBOOK not found" >&2
+  exit 4
+fi
+
+PLAYBOOK_CONTENT="$(cat "$PLAYBOOK")"
+
+# --- Build final prompt ---
+# The playbook is injected as workspace policy context, then a Goals+Constraints
+# style instruction (per "Codex Prompting Guidelines") points Codex at the
+# repo's own /resolve-issue skill while binding it to the workspace policy.
+PROMPT="$(cat <<EOF
+# Workspace Policy Context (knishioka-pm AGENTS.md)
+
+Below is the workspace-level Codex playbook. It is the source of truth for
+verification expectations, PR description format (Japanese, structured), and
+prompting style. Follow it strictly.
+
+---
+
+${PLAYBOOK_CONTENT}
+
+---
+
+# Task
+
+/resolve-issue #${ISSUE_NUMBER}
+
+【目標】
+- Issue #${ISSUE_NUMBER} (${OWNER_REPO}) を解決し、検証 + 日本語PR本文整形まで完走させた上で draft PR を作成する。
+
+【制約】
+- 上記 "Auto-Resolve via Codex" / "PR Description Standards" / "Codex Prompting Guidelines" に従うこと。
+- workspace 側 (knishioka-pm) のファイルは編集対象ではない。対象リポ ${OWNER_REPO} のみ変更する。
+- 自己修正コミットは最大3回まで。それでも失敗が残ったら隠さず ❌ で PR 本文に明示する。
+
+【検証】
+- リポ標準のチェック (build / lint / format / typecheck / test) を順に実行。失敗 0 が "good" の定義。
+- 該当しないコマンドはスキップ (埋め草で書かない)。
+
+【出力】
+- draft PR を 1 本作成する。本文は workspace AGENTS.md "PR Description Standards" のテンプレに従い、日本語で記述する。
+EOF
+)"
+
+# --- Dry-run: print prompt and exit ---
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "$PROMPT"
+  exit 0
+fi
+
+# --- Real run: invoke codex exec with timeout ---
+if ! command -v codex >/dev/null 2>&1; then
+  echo "Error: 'codex' CLI not found in PATH" >&2
+  exit 2
+fi
+
+# Prefer GNU timeout; fall back to coreutils-prefixed name on macOS without alias.
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+else
+  echo "Warning: no 'timeout' / 'gtimeout' found; running codex without external timeout" >&2
+  TIMEOUT_BIN=""
+fi
+
+# Log only the repo *name* and issue number — never the prompt body, since the
+# repo (and via it, the playbook) may be private. Codex itself logs to its own
+# session files; that is its own boundary, not ours.
+echo "[codex-resolve] start repo=${OWNER_REPO} issue=${ISSUE_NUMBER} timeout=${CODEX_TIMEOUT}s" >&2
+
+START_EPOCH="$(date +%s)"
+set +e
+if [ -n "$TIMEOUT_BIN" ]; then
+  "$TIMEOUT_BIN" "$CODEX_TIMEOUT" \
+    codex exec -C "$REPO_PATH" --full-auto "$PROMPT"
+else
+  codex exec -C "$REPO_PATH" --full-auto "$PROMPT"
+fi
+EXIT_CODE=$?
+set -e
+END_EPOCH="$(date +%s)"
+DURATION=$((END_EPOCH - START_EPOCH))
+
+echo "[codex-resolve] end repo=${OWNER_REPO} issue=${ISSUE_NUMBER} exit=${EXIT_CODE} duration_sec=${DURATION}" >&2
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## 概要

`focus-task` cron は `codex exec ... "/resolve-issue #N"` を直接叩いており、Codex は対象リポの CLAUDE.md / AGENTS.md しか読まないため、ワークスペース側の PR Description Standards / Codex Prompting Guidelines が届いていなかった。
本 PR では `scripts/codex-resolve.sh` を新設し、`docs/codex-playbook.md` を prompt に prepend してから `codex exec` を呼ぶラッパーを追加することで、12+ リポに同じポリシーを複製せずに一元管理できるようにする。

Closes #6

## 変更内容

- `scripts/codex-resolve.sh` を新設 (executable, 約 160 行)
  - 引数: `<owner/repo> <issue_number>` (位置), `--dry-run` (任意位置), `--help`
  - `config/repos.yaml` の `repos:` / `private_repos:` 双方を grep で検索しリポ存在を確認
  - ローカルパスは `LOCAL_REPO_BASE` (デフォルト `/Users/ken/Developer/private`) + リポ名で解決 (`docs/codex-playbook.md` の "ローカルリポパス" 規約に準拠)
  - `docs/codex-playbook.md` 全文 + 「Goals / Constraints / Verification / Output」を組んだ最終 prompt を生成
  - `--dry-run`: 最終 prompt を stdout に出して exit 0
  - 通常実行: `gtimeout 900` (env で `CODEX_TIMEOUT` 上書き可) で `codex exec -C $REPO_PATH --full-auto "$prompt"` を実行し、開始/終了ログ (repo 名と issue 番号のみ、prompt 本文は出さない) を stderr に出して codex の exit code をそのまま返す
  - exit code: `0` 成功, `2` 引数/設定エラー, `3` ローカルチェックアウト不在, `4` playbook 不在, `124` タイムアウト, それ以外 codex passthrough
- `AGENTS.md`
  - "Never modify these files:" から `scripts/*` を削除
  - "Interactive (Ken と対話中) のみ許可:" に `scripts/*` の追加・修正を追記 (cron / 自動セッションからは引き続き編集不可)
  - "Scripts" 表に `codex-resolve.sh` 行を追加

## 動作確認 (Verification)

ワークスペースには build / typecheck / unit test の概念がないので、CI 相当の lint と script 単体の dry-run smoke を実施。

| 項目                            | コマンド                                                                                | 結果        |
| ------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
| Bash 構文                       | `bash -n scripts/codex-resolve.sh`                                                      | ✅ pass     |
| AGENTS.md size check            | `bash scripts/check-agents-md-size.sh`                                                  | ✅ 157 行 (warn 250 / fail 500 未満) |
| markdownlint (`AGENTS.md`)      | `npx markdownlint-cli2 AGENTS.md`                                                       | ✅ 0 errors |
| markdownlint (docs/, README 等) | `npx markdownlint-cli2 docs/*.md README.md DEMO.md monitoring/OVERVIEW.md`              | ✅ 0 errors |
| YAML syntax                     | `ruby -ryaml -e "YAML.load_file('config/repos.yaml')"`                                  | ✅ pass     |
| dry-run (引数なし)              | `./scripts/codex-resolve.sh`                                                            | ✅ 期待通り exit 2 + usage 表示 |
| dry-run (位置引数 1 つ)         | `./scripts/codex-resolve.sh knishioka/kanji-practice`                                   | ✅ exit 2 + usage |
| dry-run (issue 番号が非数字)    | `./scripts/codex-resolve.sh knishioka/kanji-practice abc`                               | ✅ exit 2 + 明示エラー |
| dry-run (repos.yaml に未登録)   | `./scripts/codex-resolve.sh notinconfig/foo 999 --dry-run`                              | ✅ exit 2 + 明示エラー |
| dry-run (public)                | `./scripts/codex-resolve.sh --dry-run knishioka/kanji-practice 999`                     | ✅ exit 0, prompt に playbook の 3 セクション (`Auto-Resolve via Codex` / `PR Description Standards` / `Codex Prompting Guidelines`) を含むことを grep で確認 |
| dry-run (public, 別リポ)        | `./scripts/codex-resolve.sh --dry-run knishioka/ib-sec-mcp 999`                         | ✅ exit 0   |
| dry-run (private)               | `./scripts/codex-resolve.sh --dry-run knishioka/market-lens-studio 999`                 | ✅ exit 0 (パス `/Users/ken/Developer/private/market-lens-studio` 解決) |
| ローカルチェックアウト不在 (real run) | `LOCAL_REPO_BASE=/tmp/nope-base ./scripts/codex-resolve.sh knishioka/kanji-practice 999` | ✅ codex 呼ぶ前に exit 3 + 明示エラー |

実行ログ要約: 初回成功。`shellcheck` はローカル未インストールのため未実行 (CI の `actionlint` も workflow YAML 内 `run:` ブロックのみが対象であり本 script は未走査) — 構文は `bash -n` で確認済み。Codex CLI を実プロンプトで起動する経路は本 PR の範囲では未検証 (cron 切替は #7 の責務で、それまで `--dry-run` での挙動確認に留めるのが妥当)。

## 受け入れ条件 (Acceptance Criteria)

- [x] `scripts/codex-resolve.sh` 新設、`<owner/repo> <issue_number>` を受け取る → 位置引数のバリデーション + 正規表現チェックを実装 (script L55-77)
- [x] `repos.yaml` から該当リポを解決 (Public/Private 両対応) → `repos:` / `private_repos:` の `name:` キーを grep で検索 (script L82-89)。パスは playbook の規約 (`/Users/ken/Developer/private/{name}`) に従い両者で同一
- [x] `docs/codex-playbook.md` を読み込み prompt に prepend → 全文を `PROMPT` 変数の冒頭セクションに展開 (script L98-120)
- [x] `codex exec -C $REPO_PATH --full-auto "$prompt"` を実行 → script L142-148 で `gtimeout` 経由で起動
- [x] 終了コード・実行時間を返す → 終了コードは passthrough、実行時間は stderr に `[codex-resolve] end ... duration_sec=N` で出力 (script L150-155)
- [x] `--dry-run` モードで最終 prompt を stdout に出すだけのモード → script L122-126
- [x] AGENTS.md "Never modify" から `scripts/*` を外し interactive 限定に → AGENTS.md 35-44 行
- [x] AGENTS.md "Scripts" 表に `codex-resolve` 行を追加 → AGENTS.md 109-117 行
- [x] 1 リポで手動実行して prompt 内容と挙動を確認 → 上記 Verification の dry-run 行参照 (kanji-practice / ib-sec-mcp / market-lens-studio で確認)

## スコープ外 (Non-goals)

- `focus-task` cron prompt の編集 (=効果発現の本番投入) → #7 で対応
- `docs/codex-playbook.md` の本文修正 → 本 PR は読み込むのみで内容には触れない
- per-repo の AGENTS.md / CLAUDE.md 修正 → wrapper による一元化が目的
- `shellcheck` の CI 追加 → 本 PR の責務外 (必要であれば別 Issue 化)

## 影響範囲 / リスク

- 影響範囲: ワークスペース内のみ。新 script は cron がまだ呼んでいないため、本 PR 単体ではランタイム挙動は変わらない (Codex への playbook 注入は #7 で `focus-task` cron prompt が wrapper を呼び始めて初めて発動)
- 互換性: 既存 script の改変なし。AGENTS.md の "Never modify" 緩和は cron / 自動セッション側のガード (Allowed actions の限定) によって実質的な保護を維持
- 機密性: privateリポのリポ名はログに出すが、prompt 本文 (=リポ内容を含み得る) は stderr/stdout には書かない。Codex 自身のセッションログは Codex 側の境界
- ロールバック: `git revert` で完全に戻せる (新規ファイル + AGENTS.md の小修正のみ)

## レビュー観点 (Review Focus)

- `scripts/codex-resolve.sh:82-89` — `repos.yaml` の grep パターンが将来 `private_repos:` の追加・コメントアウトでブレないか (現行の `^[[:space:]]*-?[[:space:]]*name:[[:space:]]*${REPO_NAME}[[:space:]]*$` は十分か)。`yq` を使う方針に倒すなら brew インストール前提になる点を許容するか
- `scripts/codex-resolve.sh:98-120` — Codex に渡す最終 prompt の構造 (workspace policy → 区切り → /resolve-issue + Goals/Constraints) が "Codex Prompting Guidelines" の標準テンプレに合っているか
- `AGENTS.md:35-44` — `scripts/*` の "Interactive only" 緩和が Allowed/Interactive/Never modify の3層ポリシーで穴を開けていないか (cron / 自動セッションは依然 `Allowed autonomous actions` の列挙対象外なので script を編集できない、という解釈で合っているか)