### PR TITLE
ops(cron): switch focus-task cron to codex-resolve.sh wrapper (#7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,10 +138,12 @@ Scripts use `gh` CLI for all GitHub API calls. No direct API tokens.
 | Job                      | Schedule (KL)  | 配信                    | 目的                                                 |
 | ------------------------ | -------------- | ----------------------- | ---------------------------------------------------- |
 | weekly-repo-health       | Sun 20:00      | WhatsApp (変化時のみ)   | ヘルスレポート + サイトQA + レトロスペクティブ       |
-| focus-task               | Mon+Thu 8:30   | Issue 作成 + resolve    | Issue 自動作成 → Codex で draft PR 作成（週4件上限） |
+| focus-task[^codex-wrap]  | Mon+Thu 8:30   | Issue 作成 + resolve    | Issue 自動作成 → Codex で draft PR 作成（週4件上限） |
 | weekly-knowledge-extract | Fri 19:00      | commit                  | ナレッジ + 競合リサーチ + changelog                  |
 | monthly-portfolio-review | 第1日曜 19:00  | WhatsApp                | ポートフォリオ俯瞰 + PM Retrospective                |
 | private-repo-check       | 隔週水曜 20:00 | gitignored + Issue 作成 | private リポ監視 + Issue 作成                        |
+
+[^codex-wrap]: focus-task は `scripts/codex-resolve.sh` 経由で Codex を起動する（`docs/codex-playbook.md` をプロンプトに injection）。直接 `codex exec` は呼ばない。
 
 ### CI と cron 自動 PR の関係
 

--- a/reports/latest-focus.md
+++ b/reports/latest-focus.md
@@ -99,4 +99,4 @@
 - 銘柄単位の失敗はエラーエントリとして返す（処理を止めない）
 - 結果は `days_until_earnings` 昇順ソート
 
-変更ファイル: 4件（earnings_calendar.py 新規, tools/**init**.py, test_server.py, test_earnings_calendar.py 新規）
+変更ファイル: 4件（earnings_calendar.py 新規, `tools/__init__.py`, test_server.py, test_earnings_calendar.py 新規）

--- a/reports/latest-focus.md
+++ b/reports/latest-focus.md
@@ -1,31 +1,68 @@
 # Focus Task Report — 2026-04-30 (Thu)
 
+## 2026-05-02: cron prompt → codex-resolve.sh 切替メモ (Issue #7)
+
+`~/.openclaw/cron/jobs.json` の `focus-task` job を編集し、Codex 起動行を直接 `codex exec` から workspace の wrapper に切り替えた。
+
+| 項目          | 内容                                                                                                      |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| 切替日        | 2026-05-02                                                                                                |
+| 旧            | `codex exec -C /Users/ken/Developer/private/{repo_name} --full-auto "/resolve-issue #{issue_number}"`     |
+| 新            | `bash /Users/ken/.openclaw/workspace-knishioka-pm/scripts/codex-resolve.sh {owner}/{name} {issue_number}` |
+| backup        | `~/.openclaw/cron/jobs.json.bak.pre-codex-resolve-20260502`                                               |
+| 初回監視対象  | 次回 `focus-task` 実行 (Mon 2026-05-04 8:30 KL)                                                           |
+| rollback 手順 | `cp ~/.openclaw/cron/jobs.json.bak.pre-codex-resolve-20260502 ~/.openclaw/cron/jobs.json`                 |
+
+**狙い**: PR #3 で追加した "PR Description Standards" / "Codex Prompting Guidelines" を、wrapper 経由で workspace `docs/codex-playbook.md` ごと Codex プロンプトに注入する経路に乗せる。リポ側 CLAUDE.md / AGENTS.md には依存しない。
+
+### Dry-run 確認
+
+`bash scripts/codex-resolve.sh --dry-run knishioka/kanji-practice 999` で生成プロンプト 280 行を確認:
+
+- 冒頭に `# Workspace Policy Context (knishioka-pm AGENTS.md)` セクションで `docs/codex-playbook.md` 全文が injection される
+- `# Task` セクションで `/resolve-issue #999` + 【目標】【制約】【検証】【出力】の 4 ブロック (Codex Prompting Guidelines 準拠)
+- 対象リポを `knishioka/kanji-practice` のみに限定し、workspace 側を編集対象外と明示
+
+### 他 cron job 棚卸し
+
+`~/.openclaw/cron/jobs.json` の全 40 job を grep した結果、prompt 内で `codex exec` を直接呼ぶ job は **focus-task の 1 件のみ**。
+
+- escalation 系 (例: weekly-repo-health) は WhatsApp / commit のみで Codex を起動しない
+- private-repo-check も Issue 作成までで自動 PR 化はしない
+- → 同様の wrapper 切替が必要な後続 job は **なし**。本 Issue で完了。
+
+### 検証ゲート
+
+実 PR 生成は次回 `focus-task` (Mon 8:30 KL) に委ねる。生成された draft PR の本文が "PR Description Standards" (動作確認テーブル / 受け入れ条件 / 影響範囲 / レビュー観点 / 日本語) を満たしていることを確認後、本切替を完了とみなす。1 サイクルで PR description が壊れていた場合は backup から即 rollback する。
+
+---
+
 ## 作成した Issue + PR
 
-| Repo | Issue | PR | Type | Perspective | Subtype | Status |
-|------|-------|----|------|-------------|---------|--------|
-| knishioka/ib-sec-mcp | [#114](https://github.com/knishioka/ib-sec-mcp/issues/114) feat: 保有銘柄の決算・配当カレンダーツールを追加 | [#115](https://github.com/knishioka/ib-sec-mcp/pull/115) | feature | pm | feature | draft_pr_created ✅ |
+| Repo                 | Issue                                                                                                       | PR                                                       | Type    | Perspective | Subtype | Status              |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ------- | ----------- | ------- | ------------------- |
+| knishioka/ib-sec-mcp | [#114](https://github.com/knishioka/ib-sec-mcp/issues/114) feat: 保有銘柄の決算・配当カレンダーツールを追加 | [#115](https://github.com/knishioka/ib-sec-mcp/pull/115) | feature | pm          | feature | draft_pr_created ✅ |
 
 ## Pre-check 判定結果
 
-| 項目 | 判定 | 詳細 |
-|------|------|------|
-| Open PM Issues | 2件 (OK) | kanji-practice #31, freee-mcp #177 |
-| 直近30日 resolve率 | **66.7%** (4/6) | 50-80% → 最大 1 Issue/回 |
-| Feature count (直近4回) | 2件 | 優先フラグなし |
-| 直近4回 perspective | PM 3 : Dev 3 | バランス良好 |
+| 項目                    | 判定            | 詳細                               |
+| ----------------------- | --------------- | ---------------------------------- |
+| Open PM Issues          | 2件 (OK)        | kanji-practice #31, freee-mcp #177 |
+| 直近30日 resolve率      | **66.7%** (4/6) | 50-80% → 最大 1 Issue/回           |
+| Feature count (直近4回) | 2件             | 優先フラグなし                     |
+| 直近4回 perspective     | PM 3 : Dev 3    | バランス良好                       |
 
 → 今回: PM perspective / feature 1件 作成
 
 ## 直近4回の Perspective 比率
 
-| 日付 | Repo | Perspective | Subtype |
-|------|------|-------------|---------|
-| 2026-04-30 | ib-sec-mcp | **pm** | feature |
-| 2026-04-27 | freee-mcp | dev | tech-adoption |
-| 2026-04-26 | kanji-practice | qa | bugfix |
-| 2026-04-20 | kanji-practice | pm | feature |
-| 2026-04-20 | ib-sec-mcp | dev | maintenance |
+| 日付       | Repo           | Perspective | Subtype       |
+| ---------- | -------------- | ----------- | ------------- |
+| 2026-04-30 | ib-sec-mcp     | **pm**      | feature       |
+| 2026-04-27 | freee-mcp      | dev         | tech-adoption |
+| 2026-04-26 | kanji-practice | qa          | bugfix        |
+| 2026-04-20 | kanji-practice | pm          | feature       |
+| 2026-04-20 | ib-sec-mcp     | dev         | maintenance   |
 
 直近4回 PM:Dev = 3:3 → バランス維持
 
@@ -48,17 +85,18 @@
 
 ## Auto-Resolve 結果
 
-| Issue | Codex | テスト | PR |
-|-------|-------|--------|-----|
+| Issue           | Codex   | テスト                           | PR                                                             |
+| --------------- | ------- | -------------------------------- | -------------------------------------------------------------- |
 | ib-sec-mcp #114 | ✅ 完走 | 894/894 passed (56.17% coverage) | [#115](https://github.com/knishioka/ib-sec-mcp/pull/115) draft |
 
 ## 実装サマリ
 
 新規ファイル `ib_sec_mcp/mcp/tools/earnings_calendar.py`:
+
 - `get_earnings_calendar(symbols, days_ahead=90)` MCP ツール
 - `symbols=None` → `PositionStore` の最新スナップショットから自動取得
 - yfinance `Ticker.calendar` で Earnings Date / Ex-Dividend Date を取得
 - 銘柄単位の失敗はエラーエントリとして返す（処理を止めない）
 - 結果は `days_until_earnings` 昇順ソート
 
-変更ファイル: 4件（earnings_calendar.py 新規, tools/__init__.py, test_server.py, test_earnings_calendar.py 新規）
+変更ファイル: 4件（earnings_calendar.py 新規, tools/**init**.py, test_server.py, test_earnings_calendar.py 新規）


### PR DESCRIPTION
## 概要

Issue #7 — `~/.openclaw/cron/jobs.json` の `focus-task` job の Codex 起動行を、PR #6 で追加した `scripts/codex-resolve.sh` wrapper 経由に切り替えた。これで PR #3 で定めた "PR Description Standards" / "Codex Prompting Guidelines" が次回 cron 実行から実効化される。

## 変更内容

| ファイル                  | 変更                                                                                                                |
| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `AGENTS.md`               | Cron Jobs 表の `focus-task` 行に脚注追加。wrapper 経由であることと playbook injection を明記                        |
| `reports/latest-focus.md` | `2026-05-02` 切替メモ追加: 旧/新コマンド、backup パス、rollback 手順、dry-run 結果、他 cron job 棚卸し、検証ゲート |

## 受け入れ条件

| 条件                                                                          | 状態         | 備考                                                                                                                            |
| ----------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
| `~/.openclaw/cron/jobs.json` の `focus-task` job の prompt を更新             | ✅           | 旧 `codex exec ... "/resolve-issue #N"` → 新 `bash /Users/ken/.openclaw/workspace-knishioka-pm/scripts/codex-resolve.sh ...` |
| 編集前にバックアップを取る                                                    | ✅           | `~/.openclaw/cron/jobs.json.bak.pre-codex-resolve-20260502` (91KB)                                                              |
| dry-run / 1 ループ実行で生成 PR の description が PR Description Standards 準拠 | ⏳ 次回 cron | dry-run でプロンプト構造 (playbook injection + 4 ブロック) は確認済。実 PR 検証は次回 `focus-task` (Mon 2026-05-04 8:30 KL)     |
| 他 cron job の同様改修要否を洗い出し                                          | ✅           | 全 40 job を grep。prompt 内で `codex exec` を直接呼ぶのは focus-task のみ → 後続改修不要                                       |
| `reports/latest-focus.md` に切替日と挙動メモを残す                            | ✅           | 冒頭に新セクション追加                                                                                                          |
| `AGENTS.md` Cron Jobs 表脚注を追記                                            | ✅           | `[^codex-wrap]` 脚注で wrapper 経由を明記                                                                                       |

## 動作確認

| 確認項目                                                          | コマンド                                                                                              | 結果                                                                |
| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| backup 作成                                                       | `cp -p ~/.openclaw/cron/jobs.json{,.bak.pre-codex-resolve-20260502}`                                  | ✅ 91KB コピー完了                                                  |
| jobs.json 編集後の JSON 妥当性                                    | `python3 -c "import json; json.load(open('~/.openclaw/cron/jobs.json'))"`                             | ✅ valid                                                            |
| `codex exec` 直接呼び出しが残っていないこと                       | grep on focus-task payload                                                                            | ✅ 0 件                                                             |
| wrapper 行が入っていること                                        | grep on focus-task payload                                                                            | ✅ 1 行                                                             |
| wrapper dry-run                                                   | `bash scripts/codex-resolve.sh --dry-run knishioka/kanji-practice 999`                                | ✅ 280 行のプロンプト出力 (playbook injection + 4 ブロック構成確認) |
| markdownlint                                                      | `npx markdownlint-cli2 AGENTS.md reports/latest-focus.md`                                             | ✅ 0 errors                                                         |
| AGENTS.md サイズガード                                            | `bash scripts/check-agents-md-size.sh`                                                                | ✅ 159 lines (上限内)                                               |

## 影響範囲 / リスク

- **out-of-repo 変更**: `~/.openclaw/cron/jobs.json` の `focus-task` job 1 件の prompt 1 行のみ。他 job (39 件) は無変更。
- **影響タイミング**: 次回 `focus-task` 実行 (cron `30 8 * * 1,4` Asia/Kuala_Lumpur) — Mon 2026-05-04 8:30 KL から。
- **rollback**: 1 サイクル目の draft PR 本文が "PR Description Standards" を満たさない場合、`cp ~/.openclaw/cron/jobs.json.bak.pre-codex-resolve-20260502 ~/.openclaw/cron/jobs.json` で即時復元可能。
- **wrapper の依存**: `scripts/codex-resolve.sh` は `config/repos.yaml` の `name:` エントリでターゲット repo を validate する。新リポ追加時に repos.yaml への登録が必要 (既存の運用を踏襲)。
- 監視リポ側 (`/Users/ken/Developer/private/{name}`) には変更なし。

## レビュー観点

1. AGENTS.md の脚注表記 (`[^codex-wrap]`) が markdownlint と GitHub 両方で正しく描画されるか
2. `reports/latest-focus.md` の切替メモが将来の retrospective から発見しやすい構造か (冒頭セクション + 表 + dry-run 詳細)
3. backup ファイル名の命名規則 (`pre-codex-resolve-{YYYYMMDD}`) が既存の他 backup (`pre-autopush-{YYYYMMDD-HHMMSS}` 等) と整合しているか — 既存パターンは秒精度だが、本件は 1 日 1 回想定なので日付精度に留めた
4. 他 cron job の棚卸し結果 (focus-task のみ) が妥当か。`reports/latest-focus.md` の "他 cron job 棚卸し" セクション参照

## Non-goals

- escalation / private-repo-check 等の他 cron job 改修 (該当なしと判定)
- playbook (`docs/codex-playbook.md`) の内容追加・修正
- 監視リポ側のドキュメント追加

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)