### PR TITLE
docs(environment): consolidate workspace environment rules (Phase 0) (#15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Scripts use `gh` CLI for all GitHub API calls. No direct API tokens.
 
 ## Documents
 
+- [docs/environment.md](docs/environment.md) — Canonical Paths / Worktree 使い分け / Uncommitted Changes ポリシー / 新リポ追加手順 / 依存ツール
 - [docs/output-format.md](docs/output-format.md) — Output Format / Sub-agent Integration
 - [docs/pm-policy.md](docs/pm-policy.md) — Issue Creation / Frequency / Retrospective / Feature Discovery / Escalation / Interactive Mode / Knowledge Rules
 - [docs/codex-playbook.md](docs/codex-playbook.md) — Auto-Resolve via Codex / PR Description Standards / Codex Prompting Guidelines

--- a/docs/codex-playbook.md
+++ b/docs/codex-playbook.md
@@ -14,8 +14,10 @@ Ken の手動検証コストを最小化するのが目的。
 
 repos.yaml のリポ名からローカルパスを解決する:
 
-- Public repos: `/Users/ken/Developer/private/{name}`
-- Private repos: `/Users/ken/Developer/private/{name}`
+- Public / Private とも `/Users/ken/Developer/private/{name}` (canonical)
+
+詳細 (重複 clone の扱い、新リポ追加、dirty checkout 時の隔離方針) は
+[docs/environment.md](environment.md) を参照する。
 
 ### 実行フロー
 

--- a/docs/codex-playbook.md
+++ b/docs/codex-playbook.md
@@ -14,7 +14,7 @@ Ken の手動検証コストを最小化するのが目的。
 
 repos.yaml のリポ名からローカルパスを解決する:
 
-- Public / Private とも `/Users/ken/Developer/private/{name}` (canonical)
+- Public / Private とも `~/Developer/private/{name}` (canonical)
 
 詳細 (重複 clone の扱い、新リポ追加、dirty checkout 時の隔離方針) は
 [docs/environment.md](environment.md) を参照する。

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,118 @@
+<!-- version: 2026-05-02 -->
+
+# Workspace Environment
+
+> "リポはどこにあるか / 何が必要か / dirty な checkout をどう扱うか" の正
+> 本。cron / Codex / 人間がすべて同じ前提で動くために、暗黙だった環境ルー
+> ルをここに集約する。Phase 0 (Issue #15) は **純粋な文書化** で、振る舞
+> いの変更は伴わない。
+
+## Canonical Paths
+
+| 用途                                    | パス                                 | 備考                                                              |
+| --------------------------------------- | ------------------------------------ | ----------------------------------------------------------------- |
+| 監視リポ checkout (public + private)    | `~/Developer/private/{name}`         | `config/repos.yaml` の `repos:` / `private_repos:` 全件で同じ規約 |
+| Workspace (本リポ knishioka-pm)         | `~/.openclaw/workspace-knishioka-pm` | cron / 全 session の root                                         |
+| Wave-based 作業 worktree (本リポ Issue) | `<workspace>/.claude/worktrees/{N}`  | `/resolve-issue` などの並列作業先                                 |
+| Codex 一時隔離先 (主リポ dirty 時)      | `/tmp/{name}-issue-{N}`              | Codex 内部の現行挙動。本ドキュメントで明文化                      |
+
+`~/Developer/cost-management-mcp` のような **`/private` 配下を経由しない重
+複 clone は canonical ではない**。`scripts/codex-resolve.sh` は
+`LOCAL_REPO_BASE=/Users/ken/Developer/private` を唯一の起点として解決する
+ので、外側の clone は cron / auto-resolve から見えない。重複 clone の物理
+整理は Issue #12 で対応する。
+
+## Workspace 内 worktree vs 監視リポ直接作業
+
+| シナリオ                            | 作業場所                                                               | 起動経路                                      |
+| ----------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------- |
+| 本リポ (knishioka-pm) の Issue 並列 | `<workspace>/.claude/worktrees/{N}`                                    | `/resolve-issue {N}` (worktree skill)         |
+| 監視リポへの auto-resolve (cron)    | `~/Developer/private/{name}` (clean) / `/tmp/{name}-issue-{N}` (dirty) | `scripts/codex-resolve.sh {owner}/{name} {N}` |
+| 監視リポへの手動 PR 作業 (Ken 対話) | `~/Developer/private/{name}` 直接                                      | Ken のローカル shell                          |
+
+`<workspace>/.claude/worktrees/` は **本リポの Wave 用**。監視リポの作業を
+ここに置かない (リポ境界を越えると `gh` の auto-detect が壊れる)。
+
+## Uncommitted Changes ポリシー
+
+| 起動経路                              | 主 checkout が dirty な場合                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Codex auto-resolve (cron)             | **stash しない / pop しない**。`/tmp/{name}-issue-{N}` に隔離して作業 (現行 Codex 挙動)。主 checkout は不可侵 |
+| `/resolve-issue` interactive (本リポ) | worktree skill が `<workspace>/.claude/worktrees/{N}` を切るので主 checkout は無関係                          |
+| 監視リポでの手動作業 (Ken)            | Ken が commit / stash / 別ブランチで判断。自動化なし                                                          |
+
+**stash + 終了時 pop を採らない理由**: pop が conflict すると stash list
+に残ったまま放置されやすく、次回起動時に古い stash と新しい変更が混ざる
+事故が起こる。「主 checkout には絶対に触れない」を不変条件として保つ方
+が安全。
+
+## 新リポを監視対象に追加する手順
+
+1. `config/repos.yaml` の `repos:` (public) または `private_repos:` (private) に追記する。最低限のキー: `owner`, `name`, `language`, `priority`, `category`
+2. ローカル clone を canonical path に作成する:
+
+   ```bash
+   gh repo clone {owner}/{name} ~/Developer/private/{name}
+   ```
+
+3. dry-run で playbook 注入が成立することを確認する:
+
+   ```bash
+   bash scripts/codex-resolve.sh --dry-run {owner}/{name} 999
+   ```
+
+   出力末尾の `# Task` セクションに `/resolve-issue #999` と対象リポ名が
+   含まれていれば OK。`'{name}' not found in repos.yaml` が出る場合は手
+   順 1 のキー名を確認する。
+
+4. `monitoring/issue-tracker.jsonl` への記録は次回 cron 実行から自動。
+   手動 backfill は不要 (Phase 3 の `playbook_version` / `lint_available`
+   仕様に従う)。
+
+bootstrap script (`scripts/bootstrap-workspace.sh`) の自動化は Issue #11
+で対応する。それまでは上記を手動で実行する。
+
+## 必要な依存ツール
+
+| ツール               | 最低 version | 用途                                                                |
+| -------------------- | ------------ | ------------------------------------------------------------------- |
+| bash                 | 4.x          | `scripts/*` (associative array や `mapfile` を使う前提)             |
+| gh                   | 2.30+        | GitHub API (issue / PR / repo)                                      |
+| codex                | 0.124+       | auto-resolve (`scripts/codex-resolve.sh` から起動)                  |
+| jq                   | 1.6+         | `issue-tracker.jsonl` 解析 / 集計                                   |
+| yq                   | 4.x          | `repos.yaml` 構造化読み出し (将来用 / 現行スクリプトは grep で代用) |
+| gtimeout (coreutils) | 9.x          | `codex exec` のタイムアウト制御。fallback で `timeout` も可         |
+| markdownlint-cli2    | 0.13+        | CI lint (`.github/workflows/check.yml`)                             |
+
+確認コマンド:
+
+```bash
+bash --version | head -1
+gh --version | head -1
+codex --version
+jq --version
+yq --version
+gtimeout --version | head -1
+markdownlint-cli2 --version
+```
+
+新マシン初期化の起点:
+
+```bash
+brew install gh jq yq coreutils bash
+npm i -g @openai/codex@latest markdownlint-cli2
+gh auth login
+```
+
+## 障害復旧 (Reset Procedure)
+
+1. `~/.openclaw/workspace-knishioka-pm` を `gh repo clone knishioka/openclaw-workspace-knishioka-pm` で再取得する。
+2. `~/Developer/private/` 配下に `config/repos.yaml` の各リポを clone する (順序不問)。
+3. cron 設定 (`~/.openclaw/cron/jobs.json`) は別リポ管理外なので、個別バックアップ (`~/.openclaw/cron/jobs.json.bak.*`) から復元する。テンプレ化は Issue #11 で対応予定。
+4. 「新リポを監視対象に追加する手順」の手順 3 (dry-run) を 1 件通せば、playbook 注入経路が生きていることを確認できる。
+
+## 関連ドキュメント
+
+- [`docs/codex-playbook.md`](codex-playbook.md) — auto-resolve のプロンプト / PR Description Standards
+- [`docs/pm-policy.md`](pm-policy.md) — Issue 作成基準 / Frequency Control / Knowledge Rules
+- [`AGENTS.md`](../AGENTS.md) — Safety Rules / Cron Jobs / Documents 索引

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -18,7 +18,7 @@
 
 `~/Developer/cost-management-mcp` のような **`/private` 配下を経由しない重
 複 clone は canonical ではない**。`scripts/codex-resolve.sh` は
-`LOCAL_REPO_BASE=/Users/ken/Developer/private` を唯一の起点として解決する
+`LOCAL_REPO_BASE=~/Developer/private` を唯一の起点として解決する
 ので、外側の clone は cron / auto-resolve から見えない。重複 clone の物理
 整理は Issue #12 で対応する。
 
@@ -106,8 +106,8 @@ gh auth login
 
 ## 障害復旧 (Reset Procedure)
 
-1. `~/.openclaw/workspace-knishioka-pm` を `gh repo clone knishioka/openclaw-workspace-knishioka-pm` で再取得する。
-2. `~/Developer/private/` 配下に `config/repos.yaml` の各リポを clone する (順序不問)。
+1. `gh repo clone knishioka/openclaw-workspace-knishioka-pm ~/.openclaw/workspace-knishioka-pm` で再取得する (clone 先ディレクトリ名を明示する。デフォルトでは `openclaw-workspace-knishioka-pm` になり canonical path とずれる)。
+2. `config/repos.yaml` の各リポを canonical path (`~/Developer/private/{name}`) に clone する (順序不問)。
 3. cron 設定 (`~/.openclaw/cron/jobs.json`) は別リポ管理外なので、個別バックアップ (`~/.openclaw/cron/jobs.json.bak.*`) から復元する。テンプレ化は Issue #11 で対応予定。
 4. 「新リポを監視対象に追加する手順」の手順 3 (dry-run) を 1 件通せば、playbook 注入経路が生きていることを確認できる。
 


### PR DESCRIPTION
## 概要

`docs/environment.md` を新設し、これまで暗黙だった「リポはどこにあるか / 何が必要か / dirty checkout をどう扱うか」を 1 ファイルに集約した。cron / Codex / 人間が同じ前提で動けるようにする。Phase 0 として **純粋な文書化のみ** で、振る舞いの変更は伴わない。

Closes #15

## 変更内容

- 追加: `docs/environment.md` (118 行)
  - Canonical Paths テーブル (監視リポ・workspace・worktree・Codex 隔離先)
  - Workspace 内 worktree vs 監視リポ直接作業の使い分け表
  - Uncommitted Changes ポリシー (stash しない / pop しない / `/tmp/{name}-issue-{N}` に隔離)
  - 新リポ追加手順 (4 ステップ + dry-run 検証)
  - 必要な依存ツール表 (bash, gh ≥ 2.30, codex ≥ 0.124, jq, yq, gtimeout, markdownlint-cli2)
  - 障害復旧手順
- 更新: `AGENTS.md` "Documents" セクション先頭に `docs/environment.md` 行を追加
- 更新: `docs/codex-playbook.md` "ローカルリポパス" セクションを 4 行 → 3 行に圧縮し、詳細を `docs/environment.md` 参照に置換 (重複排除)

## 動作確認 (Verification)

| 項目                 | コマンド                                                                | 結果                          |
| -------------------- | ----------------------------------------------------------------------- | ----------------------------- |
| Lint (markdown)      | `npx markdownlint-cli2 docs/environment.md docs/codex-playbook.md AGENTS.md` | ✅ 0 errors                   |
| AGENTS.md size       | `bash scripts/check-agents-md-size.sh`                                  | ✅ OK (160 lines)             |
| 行数制約             | `wc -l docs/environment.md`                                             | ✅ 118 / 200                  |

実行ログ要約: 初回成功。`<!-- version: 2026-05-02 -->` ヘッダ付与。

## 受け入れ条件 (Acceptance Criteria)

- [x] `docs/environment.md` 新設 / 全セクション含む → 行 10-118
  - [x] ローカル checkout 規約 → "Canonical Paths"
  - [x] worktree 使い分け表 → "Workspace 内 worktree vs 監視リポ直接作業"
  - [x] uncommitted changes ポリシー (決定: stash しない / `/tmp` 隔離) → "Uncommitted Changes ポリシー"
  - [x] 新リポ追加手順 → "新リポを監視対象に追加する手順"
  - [x] 依存ツール一覧 (gh ≥ 2.30, codex ≥ 0.124, jq, gtimeout, yq, bash ≥ 4) → "必要な依存ツール"
  - [x] canonical パス定義 → "Canonical Paths" 1 行目 + cost-management-mcp 重複への注釈
- [x] `AGENTS.md` Documents セクションに `docs/environment.md` 行を追加 → AGENTS.md:156
- [x] `docs/codex-playbook.md` 冒頭ローカルリポパスに `docs/environment.md` 参照を追記 (重複最小化) → codex-playbook.md:13-20
- [x] markdownlint (CI) を pass する → 上記 Verification 表
- [x] `wc -l docs/environment.md` ≤ 200 → 118 lines

## スコープ外 (Non-goals)

- bootstrap script (`scripts/bootstrap-workspace.sh`) の実装 → Issue #11
- `~/Developer/cost-management-mcp` 重複 clone の物理削除 → Issue #12
- per-repo の AGENTS.md / PR template / verify.sh → Issue #13 以降

## 影響範囲 / リスク

- 影響API: なし (ドキュメントのみ)
- 互換性: 完全互換。`scripts/codex-resolve.sh` の `LOCAL_REPO_BASE` ロジックには触れていない
- ロールバック: `git revert` で十分。3 ファイルのみ

## レビュー観点 (Review Focus)

- `docs/environment.md:36-47` — uncommitted changes ポリシーの決定 ((b) 拒否ではなく (c) 現行 /tmp 隔離を採用)。理由を 4 行で明記したが、将来 worktree fallback に切り替える方針が望ましければ Issue を切る
- `docs/environment.md:75-85` — 依存ツールの最低 version。実機で `codex 0.124+` / `gh 2.30+` 等が満たされているかは Ken の環境のみ確認可能
- `docs/codex-playbook.md:13-20` — 重複排除の塩梅。Public/Private を 1 行に縮約し、詳細を environment.md に飛ばした

---

Generated by Claude `/resolve-issue` / Reviewed by knishioka-pm