### PR TITLE
chore: post-Wave 8 followups (status.sh bug, harness PoC pending, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ __pycache__/
 *.log
 *.tmp
 tmp/
+.claude/worktrees/

--- a/reports/spike-harness-kanji-pending-20260502.md
+++ b/reports/spike-harness-kanji-pending-20260502.md
@@ -1,0 +1,49 @@
+# Spike: kanji-practice PoC 観察 (Phase B - pending)
+
+As of: 2026-05-02
+Type: spike (pending — cron 観察待ち)
+Related: Issue #21, knishioka/kanji-practice#32
+
+## 状態
+
+Phase B (Issue #21: kanji-practice harness pack PoC) の本体作業は完了:
+
+- knishioka/kanji-practice#32 merged 2026-05-02 05:13 UTC
+- 配備内容:
+  - `AGENTS.md` (kanji-practice 固有制約: html2canvas oklch / 印刷 A4 安全領域 / src/utils/layout.ts 経由 ルール)
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+  - `scripts/verify.sh` (Node/Vite/Biome 用、`--json` で構造化出力)
+  - `.gitignore` に `.codex-progress.md` 追加
+  - 既存 `CLAUDE.md` を Claude 固有のみに整理
+
+ただし Issue #21 の Acceptance Criteria のうち「**次回 focus-task cron で生成 PR の挙動観察**」が残っており、観察結果待ちのため Issue は open のまま (※ GitHub は cross-repo PR の Closes キーワードで auto-close したが、本 workspace の運用上は観察 follow-up があるので reopen を検討)。
+
+## 観察対象
+
+次回 focus-task cron 実行 (Mon 2026-05-04 8:30 KL or Thu 2026-05-07 8:30 KL) で kanji-practice 向け Issue が選定された場合:
+
+- [ ] 生成 PR description が新テンプレ (workspace `docs/codex-playbook.md` "PR Description Standards") に準拠
+- [ ] 動作確認テーブルに `verify.sh --json` の出力 (build/lint/format/typecheck/test) が含まれる
+- [ ] `monitoring/issue-tracker.jsonl` の新レコードに `playbook_version` フィールドが入る (Issue #19 の効果検証)
+- [ ] `monitoring/issue-tracker.jsonl` の `lint_available: true` が記録される (Issue #20 の効果検証、kanji は Biome 完備)
+- [ ] Codex が `AGENTS.md` 内の kanji 固有制約 (oklch / 印刷領域 等) を読んで PR 内容に反映している
+
+## 判断 (cron 観察後に追記)
+
+### Phase C (横展開) go/no-go 判断材料
+
+- (TBD) 生成 PR 品質が現状より明確に改善 → Phase C で残り 11 リポへ展開
+- (TBD) 改善が薄い / verify.sh が Codex に活用されていない → テンプレを改善して再 PoC
+- (TBD) 不具合発見 → 改善 Issue を起票
+
+### 想定タイムライン
+
+- 2026-05-04 (月) または 2026-05-07 (木): 1 回目の観察機会
+- 2026-05-08 (金): 観察結果を本ファイルに追記、Phase C の判断
+- 2026-05-15 頃: Wave 9 (Codex hooks 評価 spike) の起動条件 (4-6 サイクル運用) 達成
+
+## アクション
+
+- [ ] 次回 focus-task cron 実行後に reports/spike-harness-kanji-{date}.md を新規作成 or 本ファイルを更新
+- [ ] 観察結果を踏まえ Issue #21 の最終 close (Phase C 計画 or 本観察自体の終了)
+- [ ] 必要なら Phase C (残り 11 リポ harness 配布) の計画を別 plan に切り出す

--- a/reports/spike-status-sh-bug-20260502.md
+++ b/reports/spike-status-sh-bug-20260502.md
@@ -1,0 +1,90 @@
+# Spike: worktree skill `status.sh` cross-repo PR の jq parse 失敗
+
+As of: 2026-05-02
+Type: spike (known issue, upstream bug)
+
+## 事象
+
+Wave 8 (Issue #21: kanji-practice PoC) の進行中、`/worktree` で `status.sh` が以下のエラーを返した:
+
+```
+jq: invalid JSON text passed to --argjson
+```
+
+`complete-wave.sh --wave 8` も同じ経路で失敗し、`unmerged: ["21 (null", "null)"]` のような壊れた表示になった。
+
+## 根本原因
+
+worktree skill (`~/.claude/skills/worktree/scripts/_gh_helpers.sh`) の `get_pr_data_for_issue` 関数:
+
+```bash
+pr_data=$(gh pr view "$closed_by" --json "$fields" 2>/dev/null | jq -s '.' || echo "[]")
+```
+
+の挙動:
+
+1. Issue #21 は **kanji-practice/32 (cross-repo)** で auto-close されている
+2. `gh issue view 21 --json closedByPullRequestsReferences` は `kanji-practice/32` を返す
+3. 関数内で `gh pr view 32` を **`--repo` 指定なし** で呼ぶ → workspace に PR #32 が無いので `GraphQL: Could not resolve to a PullRequest` エラー
+4. `set -o pipefail` (status.sh 冒頭で `set -euo pipefail`) のため、pipe の中間 fail が伝播
+5. `gh pr view ... | jq -s '.'` で gh が exit 1 → pipefail で全体 exit 1 → `|| echo "[]"` が走る
+6. しかし `jq -s '.'` は空入力を `[]` として既に出力済 → stdout に `[]\n[]` の二重連結
+7. 呼び出し元で `jq '.[0]'` がこれを受けて parse error
+
+## 影響範囲
+
+- workspace 内の Issue が cross-repo PR で close されているとき (Wave 8 のような外部リポ作業 PoC)
+- complete-wave.sh が PR を見つけられず unmerged 扱いで失敗
+- 結果として **wave-plan.json を手動編集して completed マーク**せざるを得ない (Wave 8 で実施)
+
+## 回避策 (現状)
+
+cross-repo Issue を含む Wave は:
+
+1. wave-plan.json を直接編集して `status: "completed"` + `external_pr: "owner/repo#N"` を追加
+2. tmux pane / worktree を手動で `tmux kill-pane` + `git worktree remove --force`
+3. complete-wave.sh は呼ばない
+
+## 推奨修正 (upstream)
+
+`_gh_helpers.sh` の `get_pr_data_for_issue` を以下のいずれかに修正:
+
+**案 A**: cross-repo PR を検出してスキップ (workspace と PR の repo が異なるなら null を返す)
+
+```bash
+local pr_repo
+pr_repo=$(gh issue view "$issue_num" --json closedByPullRequestsReferences \
+  --jq '.closedByPullRequestsReferences[0].repository.nameWithOwner // empty' 2>/dev/null)
+local current_repo
+current_repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+if [[ -n "$pr_repo" && "$pr_repo" != "$current_repo" ]]; then
+  echo "[]"
+  return
+fi
+```
+
+**案 B**: pipefail 影響を受けないように pipe を分解
+
+```bash
+local raw
+raw=$(gh pr view "$closed_by" --json "$fields" 2>/dev/null) || raw=""
+if [[ -n "$raw" ]]; then
+  pr_data=$(echo "$raw" | jq -s '.' 2>/dev/null || echo "[]")
+else
+  pr_data="[]"
+fi
+```
+
+両方併用が安全。
+
+## 関連 Issue / PR
+
+- 本 workspace Issue #21 (Wave 8 - kanji-practice PoC) — 本事象の発生 trigger
+- workspace Wave 8 の手動 complete マーク経緯: `.git/wave-plan.json.bak.pre-wave8-manual-20260502`
+- 関連スクリプト: `~/.claude/skills/worktree/scripts/_gh_helpers.sh`, `status.sh`, `complete-wave.sh`
+
+## アクション
+
+- [x] 事象記録 (本ファイル)
+- [ ] worktree skill 本体への upstream PR / Issue (本 workspace のスコープ外、Ken が別途判断)
+- [ ] 同種事象が再発したら同じ手動回避策を docs/environment.md に追記


### PR DESCRIPTION
## 概要

Wave 8 完了後の follow-up を 3 件まとめた小さな chore PR。Wave 計画外で発見した事象 + 観察待ち状態 + 過去の見落としを文書化する。

## 変更内容

### 1. `reports/spike-status-sh-bug-20260502.md` (新規)

Wave 8 進行中に発覚した worktree skill (`~/.claude/skills/worktree/scripts/_gh_helpers.sh`) のバグを spike report として記録。

- **事象**: cross-repo PR (kanji-practice#32) で auto-close された Issue #21 に対し、`status.sh` / `complete-wave.sh` が `jq: invalid JSON text passed to --argjson` で失敗
- **根因**: `gh pr view 32` を `--repo` 指定なしで呼んで GraphQL エラー → pipefail で `|| echo \"[]\"` が走る → stdout に `[]\n[]` 二重出力 → jq parse 失敗
- **回避策**: wave-plan.json を直接編集、tmux pane / worktree を手動 cleanup (Wave 8 で実施済)
- **推奨修正**: cross-repo PR を検出して skip、または pipe 分解で pipefail 影響を回避

これは worktree skill 本体の問題で本 workspace のスコープ外だが、再発時の対応材料として workspace に記録する。

### 2. `reports/spike-harness-kanji-pending-20260502.md` (新規)

Phase B (Issue #21: kanji-practice harness pack PoC) の観察待ち状態を記録。

- 本体作業は kanji-practice#32 で merged 済 (2026-05-02 05:13 UTC)
- AC「次回 focus-task cron で生成 PR 観察」が残るため Issue #21 は実質 open 扱い (GitHub は cross-repo PR の Closes で auto-close したが、本 workspace 運用上は観察 follow-up あり)
- 観察対象 (PR description テンプレ準拠 / verify.sh 出力 / playbook_version 記録 / lint_available 記録 / kanji 固有制約の反映) を明記
- Phase C (横展開) の go/no-go 判断のタイムライン (2026-05-04〜2026-05-15) を記載

### 3. `.gitignore`

`.claude/worktrees/` を追加。Wave 5-8 で生成された worktree ディレクトリを ignore (Phase 1 の AGENTS.md 分割時に見落としていた)。

## 動作確認 (Verification)

| 項目      | コマンド                      | 結果        |
| --------- | ----------------------------- | ----------- |
| Lint      | markdownlint (CI 経由)        | ⏳ CI 待ち  |
| Build     | n/a (docs-only)               | n/a         |
| Typecheck | n/a                           | n/a         |
| Test      | n/a (CI guardrail のみ)       | ⏳ CI 待ち  |

実行ログ要約: docs-only PR、CI で markdownlint + AGENTS.md size check が通れば green 想定。

## 受け入れ条件 (Acceptance Criteria)

本 PR は計画外 follow-up なので独立した Issue は無し。実質的な確認:

- [x] spike-status-sh-bug が事象 / 根因 / 回避策 / 推奨修正を含む
- [x] spike-harness-kanji-pending が観察対象と Phase C 判断材料を明示
- [x] .gitignore で `.claude/worktrees/` が ignore される (`git status` で worktree が見えなくなる)
- [ ] CI green

## スコープ外 (Non-goals)

- worktree skill 本体への upstream PR (本 workspace 範囲外、Ken が別途判断)
- Issue #21 の最終 close (cron 観察後に判断)
- Phase C (残り 11 リポ harness 配布) 計画 (本 PR では起票しない)

## 影響範囲 / リスク

- 影響API: なし
- 互換性: なし (純粋に追加 + .gitignore 拡張)
- ロールバック: `git revert` で完全に戻せる

## レビュー観点 (Review Focus)

- `reports/spike-status-sh-bug-20260502.md`:L48-72 — 推奨修正案 (案A: cross-repo skip / 案B: pipe 分解) が技術的に妥当か
- `reports/spike-harness-kanji-pending-20260502.md`:L25-32 — 観察対象リストの過不足
- `.gitignore`:L54 — 既存の `tmp/` の下に `.claude/worktrees/` を追加。順序は気にしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)