### PR TITLE
feat(scripts): exclude on-hold repos from bootstrap missing count

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -90,6 +90,9 @@ bash scripts/bootstrap-workspace.sh
 # 構造化出力 (CI / 他 script から parse 可能)
 bash scripts/bootstrap-workspace.sh --json | jq '.summary'
 
+# on-hold も dry-run の missing に含めて確認
+bash scripts/bootstrap-workspace.sh --include-on-hold --json | jq '.summary'
+
 # 未 clone リポを実 clone (idempotent)
 bash scripts/bootstrap-workspace.sh --apply
 ```
@@ -98,9 +101,14 @@ bash scripts/bootstrap-workspace.sh --apply
 
 - `~/Developer/private/{name}/.git` の有無を全件チェック。
 - `--apply` で未 clone を `gh repo clone` (既存は skip、`status: abandoned` / `on-hold` は自動 clone しない)。
+- `status: on-hold` はデフォルトでは informational 扱いで、未 clone でも
+  `summary.missing` に含めない。`summary.on_hold` で件数を確認する。
+- `--include-on-hold` は dry-run の互換確認用。on-hold を `summary.missing`
+  に含めて報告するが、`--apply` と併用しても on-hold は clone しない。
 - `~/Developer/{name}` (private 配下以外) の重複 clone を ⚠️ で警告のみ。
   削除は Issue #17 / Ken の手動レビュー前提 (本スクリプトは絶対に削除しない)。
-- `--json` は `{deps, mode, repos: [...], summary}` を返す。
+- `--json` は `{deps, mode, repos: [...], summary}` を返す。`repos[]` には
+  `config/repos.yaml` の `status` を含める。
 
 Exit codes:
 
@@ -141,13 +149,13 @@ markdownlint-cli2 --version
 brew install gh jq yq coreutils bash
 npm i -g @openai/codex@latest markdownlint-cli2
 gh auth login
-bash scripts/bootstrap-workspace.sh --apply  # 全リポ一括 clone
+bash scripts/bootstrap-workspace.sh --apply  # 対象リポを一括 clone (abandoned / on-hold は除外)
 ```
 
 ## 障害復旧 (Reset Procedure)
 
 1. `gh repo clone knishioka/openclaw-workspace-knishioka-pm ~/.openclaw/workspace-knishioka-pm` で再取得する (clone 先ディレクトリ名を明示する。デフォルトでは `openclaw-workspace-knishioka-pm` になり canonical path とずれる)。
-2. `bash scripts/bootstrap-workspace.sh --apply` で `config/repos.yaml` の全リポを canonical path (`~/Developer/private/{name}`) に一括 clone する。
+2. `bash scripts/bootstrap-workspace.sh --apply` で `config/repos.yaml` の対象リポを canonical path (`~/Developer/private/{name}`) に一括 clone する (`status: abandoned` / `on-hold` は除外)。
 3. cron 設定 (`~/.openclaw/cron/jobs.json`) は別リポ管理外なので、個別バックアップ (`~/.openclaw/cron/jobs.json.bak.*`) から復元する。テンプレ化は Issue #11 で対応予定。
 4. 「新リポを監視対象に追加する手順」の手順 3 (dry-run) を 1 件通せば、playbook 注入経路が生きていることを確認できる。
 

--- a/reports/latest-health.md
+++ b/reports/latest-health.md
@@ -30,6 +30,7 @@
 | english-note-maker | 🟢 GREEN | ✅ | 1d | 0 | 0 | — |
 
 ### Abandoned (skipped for issues)
+
 | Repo | Status | Inactive |
 |------|--------|----------|
 | td-mcp-server | 🔴 RED | 273d |

--- a/reports/monthly-portfolio-2026-05.md
+++ b/reports/monthly-portfolio-2026-05.md
@@ -8,6 +8,7 @@ Summary: Active 10 / Dormant 1 / Abandoned 4
 ## Portfolio classification
 
 ### Public repos
+
 | Repo | Category | Days inactive | Status |
 |------|----------|--------------|--------|
 | kanji-practice | education | 1 | Active |
@@ -22,6 +23,7 @@ Summary: Active 10 / Dormant 1 / Abandoned 4
 | remotion-math-education | education | 320 | Abandoned |
 
 ### Private repos
+
 | Repo | Days inactive | Status |
 |------|--------------|--------|
 | market-lens-studio | 15 | Active |

--- a/scripts/bootstrap-workspace.sh
+++ b/scripts/bootstrap-workspace.sh
@@ -190,17 +190,9 @@ while IFS= read -r repo_json; do
   if $present; then
     action="skip"
   elif $is_on_hold; then
+    # on-hold は意図的に未 clone のことがあるため、--apply でも絶対 clone しない。
     if (( INCLUDE_ON_HOLD )); then
       MISSING_CT=$((MISSING_CT + 1))
-    fi
-    if (( APPLY )); then
-      # on-hold は意図的に未 clone のことがあるため、--apply でも絶対 clone しない。
-      if (( INCLUDE_ON_HOLD )); then
-        action="missing-on-hold"
-      else
-        action="skip-on-hold"
-      fi
-    elif (( INCLUDE_ON_HOLD )); then
       action="missing-on-hold"
     else
       action="skip-on-hold"

--- a/scripts/bootstrap-workspace.sh
+++ b/scripts/bootstrap-workspace.sh
@@ -10,6 +10,8 @@
 # Usage:
 #   scripts/bootstrap-workspace.sh                 # dry-run 人間向けレポート
 #   scripts/bootstrap-workspace.sh --json          # dry-run 構造化出力
+#   scripts/bootstrap-workspace.sh --include-on-hold --json
+#                                                   # on-hold も missing に含めて報告
 #   scripts/bootstrap-workspace.sh --apply         # 未 clone を実 clone
 #   scripts/bootstrap-workspace.sh --apply --json  # apply + JSON
 #
@@ -40,10 +42,12 @@ usage() {
 # --- Parse args ---------------------------------------------------------------
 APPLY=0
 JSON=0
+INCLUDE_ON_HOLD=0
 for arg in "$@"; do
   case "$arg" in
-    --apply) APPLY=1 ;;
-    --json)  JSON=1 ;;
+    --apply)           APPLY=1 ;;
+    --json)            JSON=1 ;;
+    --include-on-hold) INCLUDE_ON_HOLD=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Error: unknown arg: $arg" >&2; usage >&2; exit 2 ;;
   esac
@@ -141,6 +145,7 @@ fi
 TOTAL=0
 PRESENT=0
 MISSING_CT=0
+ON_HOLD_CT=0
 DUPLICATE_CT=0
 APPLIED=0
 CLONE_ERRORS=0
@@ -160,6 +165,11 @@ while IFS= read -r repo_json; do
   owner="$(jq -r '.owner' <<< "$repo_json")"
   name="$(jq  -r '.name'  <<< "$repo_json")"
   status="$(jq -r '.status // ""' <<< "$repo_json")"
+  is_on_hold=false
+  if [ "${status}" = "on-hold" ]; then
+    is_on_hold=true
+    ON_HOLD_CT=$((ON_HOLD_CT + 1))
+  fi
 
   expected_path="${LOCAL_REPO_BASE}/${name}"
   duplicate_path="${DEVELOPER_BASE}/${name}"
@@ -179,11 +189,27 @@ while IFS= read -r repo_json; do
 
   if $present; then
     action="skip"
+  elif $is_on_hold; then
+    if (( INCLUDE_ON_HOLD )); then
+      MISSING_CT=$((MISSING_CT + 1))
+    fi
+    if (( APPLY )); then
+      # on-hold は意図的に未 clone のことがあるため、--apply でも絶対 clone しない。
+      if (( INCLUDE_ON_HOLD )); then
+        action="missing-on-hold"
+      else
+        action="skip-on-hold"
+      fi
+    elif (( INCLUDE_ON_HOLD )); then
+      action="missing-on-hold"
+    else
+      action="skip-on-hold"
+    fi
   else
     MISSING_CT=$((MISSING_CT + 1))
     if (( APPLY )); then
-      if [ "${status}" = "abandoned" ] || [ "${status}" = "on-hold" ]; then
-        # 放棄/保留中のリポは --apply でも自動 clone しない (idempotent + 安全)
+      if [ "${status}" = "abandoned" ]; then
+        # 放棄中のリポは --apply でも自動 clone しない (idempotent + 安全)
         action="skip-status"
       elif gh repo clone "${owner}/${name}" "${expected_path}" -- --quiet --depth=1; then
         APPLIED=$((APPLIED + 1))
@@ -226,6 +252,7 @@ if (( JSON )); then
     --argjson total       "$TOTAL" \
     --argjson present     "$PRESENT" \
     --argjson missing     "$MISSING_CT" \
+    --argjson on_hold     "$ON_HOLD_CT" \
     --argjson duplicates  "$DUPLICATE_CT" \
     --argjson applied     "$APPLIED" \
     --argjson errors      "$CLONE_ERRORS" \
@@ -237,6 +264,7 @@ if (( JSON )); then
          total: $total,
          present: $present,
          missing: $missing,
+         on_hold: $on_hold,
          duplicates: $duplicates,
          applied: $applied,
          clone_errors: $errors
@@ -244,7 +272,7 @@ if (( JSON )); then
      }' "$RESULTS_FILE"
 else
   echo "Workspace bootstrap report (mode: ${MODE})"
-  echo "  total=${TOTAL} present=${PRESENT} missing=${MISSING_CT} duplicates=${DUPLICATE_CT} applied=${APPLIED} errors=${CLONE_ERRORS}"
+  echo "  total=${TOTAL} present=${PRESENT} missing=${MISSING_CT} on_hold=${ON_HOLD_CT} duplicates=${DUPLICATE_CT} applied=${APPLIED} errors=${CLONE_ERRORS}"
   echo
 
   while IFS= read -r line; do
@@ -257,7 +285,9 @@ else
       would-clone)  icon="📥" ; msg="missing (would clone with --apply)" ;;
       cloned)       icon="✨" ; msg="cloned" ;;
       clone-failed) icon="❌" ; msg="clone failed" ;;
-      skip-status)  icon="⏭" ; msg="skipped (abandoned / on-hold)" ;;
+      skip-status)  icon="⏭" ; msg="skipped (abandoned)" ;;
+      skip-on-hold) icon="ℹ️" ; msg="on-hold (skipped; not counted missing)" ;;
+      missing-on-hold) icon="ℹ️" ; msg="on-hold missing (included by --include-on-hold; --apply still skips)" ;;
       *)            icon="?"  ; msg="$action" ;;
     esac
     printf '  %s %-32s  %s\n' "$icon" "$name" "$msg"


### PR DESCRIPTION
## 概要

`status: on-hold` の監視リポを bootstrap の missing 警告から分離し、意図的に未 clone のリポが運用上のノイズにならないようにしました。デフォルトでは `summary.on_hold` に分けて表示し、互換確認用に `--include-on-hold` も追加しています。

Closes #29

## 変更内容

- `scripts/bootstrap-workspace.sh`
  - `--include-on-hold` オプションを追加
  - デフォルトでは on-hold 未 clone を `summary.missing` から除外し、`summary.on_hold` に集計
  - `--include-on-hold` 指定時は on-hold を missing に含めて報告
  - `--apply` と併用しても on-hold は clone しないように明示
- `docs/environment.md`
  - bootstrap の on-hold 集計、`--include-on-hold`、JSON `repos[].status` を説明
  - setup/reset 手順の「全リポ clone」表現を、abandoned / on-hold 除外を含む表現に修正
- `reports/latest-health.md`, `reports/monthly-portfolio-2026-05.md`
  - PR CI で既存 markdownlint エラーになっていた table 前後の空行だけを修正

## 動作確認 (Verification)

| 項目 | コマンド | 結果 |
| --- | --- | --- |
| Shell syntax | `bash -n scripts/bootstrap-workspace.sh` | ✅ pass |
| Diff whitespace | `git diff --check -- scripts/bootstrap-workspace.sh docs/environment.md reports/latest-health.md reports/monthly-portfolio-2026-05.md` | ✅ pass |
| Default JSON behavior | temp `LOCAL_REPO_BASE` + `bash scripts/bootstrap-workspace.sh --json` | ✅ `total=17`, `missing=15`, `on_hold=2` |
| Include on-hold behavior | temp `LOCAL_REPO_BASE` + `bash scripts/bootstrap-workspace.sh --include-on-hold --json` | ✅ `missing=17`, `on_hold=2` |
| Apply safety | temp checkout dirs + `bash scripts/bootstrap-workspace.sh --apply --include-on-hold --json` | ✅ `present=15`, `missing=2`, `applied=0`, `clone_errors=0` |
| YAML syntax | `ruby -ryaml -e 'Dir["config/*.{yaml,yml}"].each { |f| YAML.load_file(f) }'` | ✅ pass |
| JSONL syntax | `ruby -rjson -e 'Dir["**/*.jsonl"].each { ... }'` | ✅ pass |
| AGENTS size | `bash scripts/check-agents-md-size.sh` | ✅ 0 fail, 0 warn |
| Markdown lint | GitHub Actions `markdownlint` | ✅ pass after reports spacing fix |
| actionlint | GitHub Actions `actionlint` | pending CI rerun |

実行ログ要約: script の構文・JSON挙動・apply安全性は初回成功。初回 CI は unrelated reports table spacing で落ちたため、空行のみ追加して再実行しています。

## 受け入れ条件 (Acceptance Criteria)

- [x] `status: on-hold` のリポを missing 警告ではなく info カテゴリで扱う → default JSON で `missing=15`, `on_hold=2` を確認
- [x] JSON 出力の `summary` に `on_hold` カウントを追加 → `.summary.on_hold == 2` を確認
- [x] JSON 出力の `repos[]` に `status` フィールドを追加 → 既存の `status` 出力を維持
- [x] `--include-on-hold` で従来通り on-hold も missing に含める → `missing=17`, `on_hold=2` を確認
- [x] `--apply` モードでは on-hold は絶対 clone しない → temp checkout で `applied=0`, `clone_errors=0` を確認
- [x] `docs/environment.md` の bootstrap 説明セクションを更新 → on-hold / `--include-on-hold` / `repos[].status` を追記

## スコープ外 (Non-goals)

- abandoned 3 リポの archive 判断
- `config/repos.yaml` のスキーマ変更
- on-hold リポへの自動通知 / 復活ワークフロー
- repo name の追加バリデーションや `sort -V` 互換性改善

## 影響範囲 / リスク

- 影響API: CLI 出力と JSON summary に `on_hold` を追加。既存フィールドは削除なし。
- 互換性: デフォルトの `missing` 数は on-hold を除外するため変化します。従来値を確認したい場合は `--include-on-hold` を使えます。
- ロールバック: `git revert` で十分です。

## レビュー観点 (Review Focus)

- `scripts/bootstrap-workspace.sh` — `--include-on-hold` と `--apply` 併用時に clone しない分岐になっているか
- `docs/environment.md` — bootstrap の運用説明が Ken の期待する on-hold ポリシーと一致しているか
- `reports/*.md` — CI unblock のための空行のみで内容変更がないか

## スクリーンショット / 出力例

```json
{
  "total": 17,
  "present": 0,
  "missing": 15,
  "on_hold": 2,
  "duplicates": 0,
  "applied": 0,
  "clone_errors": 0
}
```

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm