### PR TITLE
chore(docs): 既知運用障害を environment.md に追記 + di-* spillover を gitignore 退避

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ __pycache__/
 *.tmp
 tmp/
 .claude/worktrees/
+
+# Spillover from other workspaces (manual quarantine, move to correct workspace later)
+_di-spillover/

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -159,6 +159,23 @@ bash scripts/bootstrap-workspace.sh --apply  # 対象リポを一括 clone (aban
 3. cron 設定 (`~/.openclaw/cron/jobs.json`) は別リポ管理外なので、個別バックアップ (`~/.openclaw/cron/jobs.json.bak.*`) から復元する。テンプレ化は Issue #11 で対応予定。
 4. 「新リポを監視対象に追加する手順」の手順 3 (dry-run) を 1 件通せば、playbook 注入経路が生きていることを確認できる。
 
+## 既知の運用障害 (無視可)
+
+OpenClaw runner や外部依存に起因する周期的な warning / error。**本体機能は無傷**。
+
+### WhatsApp 配信失敗で `weekly-repo-health` が `lastRunStatus: error` になる
+
+- **症状**: WhatsApp Web セッションが status 499 で 30 分ごとに切断 → 自動 retry で復旧。配信タイミングと不一致だと cron job が `error` 扱い + `lastError: "⚠️ ✉️ Message failed"` を記録 (例: 2026-05-03 weekly-repo-health)
+- **影響**: 通知遅延のみ。health check / Issue 作成 / commit / `monitoring/health-trend.jsonl` 追記は成功している
+- **対応不要**: `consecutiveErrors` が `failureAlert.after` (= 2) に達するまで放置。閾値超過したら個別調査
+- **将来的改善**: cron runner 側で配信失敗を非致命扱いにする upstream 設定が必要 (本 workspace スコープ外)
+
+### `_di-spillover/` (gitignored) に入っている scripts / reports
+
+- **由来**: `datainformed-jp/di-*` リポ向け orchestrator scripts と reports が、過去 Ken の手動作業で誤って knishioka-pm 内に作成された
+- **対応**: gitignore 退避済 (commit 対象外)。Ken が `~/.openclaw/workspace-di/scripts/` 等の正しい workspace に `mv` してから `_di-spillover/` を削除
+- **詳細**: `_di-spillover/README.md`
+
 ## 関連ドキュメント
 
 - [`docs/codex-playbook.md`](codex-playbook.md) — auto-resolve のプロンプト / PR Description Standards


### PR DESCRIPTION
## 概要

2026-05-05 の workspace 健全性確認で見つけた 2 件の観察事項を整理する小 docs PR。

## 変更内容

### 1. `docs/environment.md` に "既知の運用障害" 節を新設

- **WhatsApp 配信失敗で weekly-repo-health が lastRunStatus=error になる**
  - 症状 / 影響 / 対応不要の閾値 / 将来的改善 (upstream) を記載
  - 本体機能 (health check / Issue 作成 / commit) は無傷
- **`_di-spillover/` (gitignored) に入っている scripts / reports**
  - 由来と Ken が正しい workspace に `mv` して削除する手順への参照

### 2. `.gitignore` に `_di-spillover/` を追加

- `datainformed-jp/di-*` リポ向け orchestrator scripts (10 件) + reports (5 件) を `_di-spillover/` に退避
- 退避済ファイル一覧と移動先候補を `_di-spillover/README.md` に記載 (本ファイルも gitignored)
- workspace の `git status` がクリーンに

## 動作確認 (Verification)

| 項目      | コマンド                                  | 結果        |
| --------- | ----------------------------------------- | ----------- |
| Lint      | markdownlint (CI 経由)                    | ⏳ CI 待ち  |
| AGENTS.md size | `scripts/check-agents-md-size.sh` (CI) | ⏳ CI 待ち  |
| git status | `git status --short`                     | ✅ ノイズ排除 (di-* 全件退避済) |

## 受け入れ条件 (Acceptance Criteria)

- [x] WhatsApp 失敗の既知問題が docs に記録され、再発時に「無視可」判断ができる
- [x] di-* spillover が gitignore で git status から消える
- [x] `_di-spillover/README.md` で Ken が後で移動判断できる材料が揃う
- [ ] CI green

## スコープ外 (Non-goals)

- `_di-spillover/` の物理移動 / 削除 (Ken 手動判断、本 workspace から強制実行しない)
- `scripts/codex-resolve.sh` の subscription check 追加 (Ken の手動改善が pending、別 PR で commit 検討)
- WhatsApp 配信失敗の upstream 修正 (OpenClaw runner 側、本 workspace スコープ外)

## 影響範囲 / リスク

- 影響API: なし (docs + .gitignore のみ)
- 互換性: 既存 git tracked ファイルに変更なし
- ロールバック: `git revert` で完全に戻せる

## レビュー観点

- `docs/environment.md`:L155-170 — "既知の運用障害" 節の表現が「無視可」判断材料として適切か
- `_di-spillover/README.md` — Ken が後で読んで意図と移動先候補が明確か (workspace-di / workspace-ds-pm のどちらかは Ken 判断)

## 残 untracked (本 PR では触らず)

- `scripts/codex-resolve.sh` (M) + `scripts/lib/require-codex-subscription.sh` (新規)
  - Ken が 2026-05-05 朝に手動で追加した ChatGPT subscription auth check 機構
  - 本 workspace に commit する価値あり (今日朝の `refresh_token_reused` 401 への対応と推測)
  - 別 PR で Ken 自身が commit する想定で本 PR では触らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)