### PR TITLE
chore(cron): podcast 等 3 job の delivery.mode を announce → none に変更

### DIFF
--- a/reports/cron-delivery-none-20260505.md
+++ b/reports/cron-delivery-none-20260505.md
@@ -1,0 +1,58 @@
+# Cron `delivery.mode` 整理 (2026-05-05)
+
+## 背景
+
+ユーザ報告: 「podcast 生成時に WhatsApp に作成途中の報告なども投稿されている」。
+ログ調査で `2026-05-05 05:12:26` に同一 sha256 のメッセージが 8 回連投されており、
+これが「不要な投稿」の正体と特定。
+
+## 根本原因
+
+`~/.openclaw/cron/jobs.json` の各 job には `delivery.mode` フィールドがあり、`announce` は cron runner が prompt 外で開始/完了/エラーを自動 WhatsApp 投稿する。prompt 内で
+WhatsApp 送信ロジックを持つ job では **二重配信** + **runner retry の連投** が発生する。
+
+## 監査結果 (2026-05-05 朝)
+
+| Job                         | 旧 mode    | prompt 内 WhatsApp 送信    | 判定                  | 新 mode           |
+| --------------------------- | ---------- | -------------------------- | --------------------- | ----------------- |
+| ai-english-daily (personal) | `announce` | ✅ Step 7 + 失敗 fallback  | 二重配信源 → 修正対象 | `none`            |
+| weekly-repo-health          | `announce` | ✅ prompt 末尾の配信ルール | 二重配信源 → 修正対象 | `none`            |
+| private-repo-check          | `announce` | ✅ Issue 作成完了通知      | 二重配信源 → 修正対象 | `none`            |
+| monthly-portfolio-review    | `announce` | ❌ なし                    | 唯一の通知経路 → 残す | `announce` (維持) |
+| focus-task                  | `none`     | ✅ Step 16 で WhatsApp     | 既に正常              | `none` (維持)     |
+| weekly-knowledge-extract    | `none`     | (commit のみ)              | 既に正常              | `none` (維持)     |
+
+## 実施した変更
+
+```bash
+# backup
+cp ~/.openclaw/cron/jobs.json ~/.openclaw/cron/jobs.json.bak.pre-delivery-none-20260505
+
+# 3 job の delivery.mode を "announce" → "none" に変更
+jq '
+  (.jobs[] | select(.name=="ai-english-daily") | .delivery.mode) |= "none" |
+  (.jobs[] | select(.name=="weekly-repo-health") | .delivery.mode) |= "none" |
+  (.jobs[] | select(.name=="private-repo-check") | .delivery.mode) |= "none"
+' ~/.openclaw/cron/jobs.json > /tmp/jobs.json.new && mv /tmp/jobs.json.new ~/.openclaw/cron/jobs.json
+```
+
+## 期待される副次効果
+
+- **weekly-repo-health の `lastRunStatus: error` も解消される見込み**: 5/3 の `lastError: "⚠️ ✉️ Message failed"` は `announce` 経路の delivery 失敗が原因。`none` で runner の自動配信が止まれば、prompt 内の `message` ツール呼び出しのみが配信経路となり、その失敗は `bestEffort: true` で job 全体は `ok` を返す
+- `docs/environment.md` "既知の運用障害" 節の WhatsApp 失敗エントリも次回 weekly-repo-health (Sun 2026-05-10) で **再発しなければ削除**できる
+
+## 検証ゲート
+
+- 次回 ai-english-daily (毎日 05:00 KL = 21:00 UTC) で 1 通 (Step 7 の正規配信) のみが届くか観察
+- 次回 weekly-repo-health (Sun 2026-05-10 20:00 KL) で `lastRunStatus: ok` になり、prompt 内の WhatsApp 通知 (1 通) のみが届くか観察
+- 次回 private-repo-check (隔週水曜 20:00 KL = 12:00 UTC) で同上
+
+## ロールバック手順
+
+```bash
+cp ~/.openclaw/cron/jobs.json.bak.pre-delivery-none-20260505 ~/.openclaw/cron/jobs.json
+```
+
+## 関連
+
+- 前 PR (#32, 2026-05-05): `docs/environment.md` "既知の運用障害" 節新設 — WhatsApp 失敗の症状記録 (本変更で解消見込み)


### PR DESCRIPTION
## 概要

ユーザ報告「podcast 生成時に WhatsApp に作成途中の報告も投稿される」を受けて `~/.openclaw/cron/jobs.json` を監査。`delivery.mode=announce` が cron runner の prompt 外自動投稿の犯人で、prompt 内に WhatsApp 送信指示を持つ job では二重配信 + retry 連投が発生していた。

実証: 5/5 朝 05:12:26 に同一 sha256 のメッセージが **8 回連投**されていることをログで確認。

## 変更内容

`~/.openclaw/cron/jobs.json` (workspace 外、backup 取得済) の 3 job の `delivery.mode` を `"announce"` → `"none"` に変更。

| Job | 旧 mode | prompt 内 WhatsApp 送信 | 新 mode |
|---|---|---|---|
| ai-english-daily (personal) | announce | ✅ Step 7 + 失敗 fallback | **none** |
| weekly-repo-health | announce | ✅ prompt 末尾の配信ルール | **none** |
| private-repo-check | announce | ✅ Issue 作成完了通知 | **none** |
| monthly-portfolio-review | announce | ❌ なし (唯一の通知経路) | announce (維持) |
| focus-task / weekly-knowledge-extract | none | (該当時のみ) | none (維持) |

`reports/cron-delivery-none-20260505.md` に背景・監査結果・ロールバック手順を記録。

## 動作確認 (Verification)

| 項目 | コマンド | 結果 |
|---|---|---|
| Lint | markdownlint (CI 経由) | ⏳ CI 待ち |
| jobs.json validity | `jq . ~/.openclaw/cron/jobs.json > /dev/null` | ✅ pass (実施済) |
| Backup 存在 | `ls -la ~/.openclaw/cron/jobs.json.bak.pre-delivery-none-20260505` | ✅ 存在 |
| Mode 反映 | `jq '.jobs[] | select(.delivery.mode == "none") | .name' ~/.openclaw/cron/jobs.json` | ✅ 5 job (focus-task / weekly-knowledge-extract / 新規 3 件) |

## 受け入れ条件

- [x] 3 job の delivery.mode が "none" に変更され jq で確認できる
- [x] backup が取得されロールバック可能
- [x] reports/cron-delivery-none-20260505.md に変更経緯と検証ゲートが記録
- [ ] CI green
- [ ] 次回 ai-english-daily (毎日 05:00 KL) で 1 通のみ届く (本 PR マージ後の cron 観察)
- [ ] 次回 weekly-repo-health (Sun 2026-05-10) で `lastRunStatus: ok` + 1 通のみ届く

## 期待される副次効果

5/3 weekly-repo-health の `lastError: "⚠️ ✉️ Message failed"` も `announce` 経路の delivery 失敗が原因なので、本変更で解消見込み。次回 weekly-repo-health で `ok` になれば `docs/environment.md` "既知の運用障害" 節の WhatsApp 失敗エントリも削除候補。

## スコープ外

- monthly-portfolio-review の announce: prompt 内送信がないので唯一の通知経路、維持
- 他 workspace (ds-pm, ds-tm, di) の cron 整理: 本 PR は podcast + knishioka-pm 関連のみ
- WhatsApp connection 不安定 (status 499) の upstream 対応

## 影響範囲 / リスク

- 影響API: cron runner の自動 announce が止まる (3 job)
- 互換性: prompt 内の `message` ツール呼び出しは無傷、本来の通知は届く
- ロールバック: `cp ~/.openclaw/cron/jobs.json.bak.pre-delivery-none-20260505 ~/.openclaw/cron/jobs.json`
- リスク評価: 低 — runner の自動 announce が無くても prompt 内ロジックで通知される

## レビュー観点

- `reports/cron-delivery-none-20260505.md`:L19-26 — 各 job の判定 (none vs announce 維持) が正しいか
- 特に **monthly-portfolio-review** を announce のまま残した判断: prompt 内送信が無いため runner 配信が唯一経路。問題なければ維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)