### PR TITLE
refactor(cron): cron ジョブ定義をリポ配下でgit管理化（ds-pm方式を移植）

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,15 @@ jobs:
           done
           exit "$fail"
 
+      - name: cron manifest builds (config/cron/jobs.yaml)
+        # Issue #37: config/cron/jobs.yaml is the source-of-truth for cron jobs.
+        # Offline verify confirms it parses and the manifest is self-consistent
+        # (no openclaw runtime needed). PyYAML lets build-cron-jobs.py skip its
+        # `uv run` fallback.
+        run: |
+          python3 -m pip install --quiet pyyaml
+          bash scripts/verify-cron-playbooks.sh --offline
+
       - name: jsonl syntax (tracked *.jsonl)
         run: |
           mapfile -t files < <(git ls-files '*.jsonl')

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 memory/
 MEMORY.md
 
+# Cron manifest (generated from config/cron/jobs.yaml by scripts/build-cron-jobs.py)
+# The live registry (~/.openclaw/cron/jobs.json + jobs-state.json) is outside
+# this repo and is never tracked; the source-of-truth is config/cron/jobs.yaml.
+build/
+
 # Runtime state
 monitoring/repo-state.json
 monitoring/latest-health.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ Scripts use `gh` CLI for all GitHub API calls. No direct API tokens.
 
 [^codex-wrap]: focus-task は `scripts/codex-resolve.sh` 経由で Codex を起動する（`docs/codex-playbook.md` をプロンプトに injection）。直接 `codex exec` は呼ばない。
 
+ジョブ定義は `config/cron/jobs.yaml` で git 管理する（編集 → 生成 → 検証 → commit）。手順は [docs/cron.md](docs/cron.md) 参照。`~/.openclaw/cron/jobs.json` を手編集しない。
+
 ### CI と cron 自動 PR の関係
 
 - このワークスペースは `.github/workflows/check.yml` で push / PR 時に最低限の lint を回す（markdownlint・actionlint・YAML/JSONL 構文・AGENTS.md サイズ）。所要時間は数十秒以内を想定。
@@ -158,4 +160,5 @@ Scripts use `gh` CLI for all GitHub API calls. No direct API tokens.
 - [docs/output-format.md](docs/output-format.md) — Output Format / Sub-agent Integration
 - [docs/pm-policy.md](docs/pm-policy.md) — Issue Creation / Frequency / Retrospective / Feature Discovery / Escalation / Interactive Mode / Knowledge Rules
 - [docs/codex-playbook.md](docs/codex-playbook.md) — Auto-Resolve via Codex / PR Description Standards / Codex Prompting Guidelines
+- [docs/cron.md](docs/cron.md) — Cron ジョブ定義の git 管理（config/cron/jobs.yaml）/ 編集→生成→検証→commit / state 保持設計
 - [docs/education-qa.md](docs/education-qa.md) — 教育軸チェック / UX軸チェック / Demo Site QA

--- a/README.md
+++ b/README.md
@@ -57,8 +57,16 @@ for repo in $(yq '.repos[].owner + "/" + .repos[].name' config/repos.yaml); do
 done
 ```
 
+## Cron Jobs
+
+Cron job definitions live in `config/cron/jobs.yaml` (git-managed source-of-truth).
+Edit that file, then run `scripts/build-cron-jobs.py` → `scripts/verify-cron-playbooks.sh`
+→ `scripts/register-cron-jobs.sh`. See [docs/cron.md](docs/cron.md). The live
+registry (`~/.openclaw/cron/jobs.json`) is never hand-edited.
+
 ## Requirements
 
 - `gh` CLI (authenticated)
 - `jq`
 - `yq` (optional, for parsing repos.yaml)
+- `python3` (+ `pyyaml` or `uv`, for the cron build/verify scripts)

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -1,0 +1,310 @@
+# Canonical knishioka-pm cron job definitions (source-of-truth).
+#
+# This file is git-managed so every cron change is reviewable in a PR and
+# the live registry (~/.openclaw/cron/jobs.json, NOT git-tracked) can be
+# drift-checked against it.
+#
+# Workflow (see docs/cron.md):
+#   1. Edit this file.
+#   2. scripts/build-cron-jobs.py                # regenerate build/cron/manifest.json
+#   3. scripts/verify-cron-playbooks.sh --live   # diff manifest vs live registry
+#   4. scripts/register-cron-jobs.sh             # apply (edits in place, preserves state)
+#   5. git commit config/cron/jobs.yaml
+#
+# Editing rules:
+#   - `message` is the full agent prompt (knishioka jobs have no separate
+#     playbook file). Keep it verbatim; the drift checker hashes it.
+#   - `defaults` hold the values shared by every job. A job key overrides the
+#     matching default. tz, agent_id, session_target, wake_mode, enabled,
+#     thinking and failure_alert all default here.
+#   - Per-job `delivery`, `timeout_seconds`, and `model` vary and live on the
+#     job. `delivery.mode: none` means the job never fallback-posts its final
+#     text; `announce` forwards it to `channel`/`to`.
+#   - Changing schedule `expr` reschedules a job. register-cron-jobs.sh edits
+#     the existing job by name so its nextRun/lastRun state is preserved.
+
+schema_version: 1
+defaults:
+  agent_id: knishioka-pm
+  tz: Asia/Kuala_Lumpur
+  enabled: true
+  session_target: isolated
+  wake_mode: now
+  thinking: medium
+  failure_alert:
+    after: 2
+    channel: whatsapp
+    to: "+819050822879"
+    cooldown_ms: 21600000
+    mode: announce
+    account_id: knishioka-pm
+    best_effort: true
+jobs:
+  - name: weekly-repo-health
+    description: Weekly health diagnosis of personal GitHub repos
+    schedule:
+      kind: cron
+      expr: 0 20 * * 0
+    timeout_seconds: 900
+    delivery:
+      mode: none
+      channel: whatsapp
+      to: "+819050822879"
+      best_effort: true
+    message: |
+      Weekly repo health check with trend tracking + site QA + Issue retrospective.
+
+      == Part 1: Health Check ==
+      1) config/repos.yaml の repos: セクションを読んで public 監視対象リストを取得
+      2) monitoring/health-trend.jsonl を読んで前回の各リポステータスを取得（なければ初回扱い）
+      3) 各リポに対して scripts/repo-health {owner}/{name} を実行
+      4) 前回と比較: ステータス遷移を検出
+      5) AGENTS.md の Output Format に従って reports/latest-health.md に出力
+      6) monitoring/health-trend.jsonl に追記
+      7) knowledge/CHANGELOG.md があれば参照してコンテキスト補足
+
+      == Part 2: Demo Site QA ==
+      8) config/repos.yaml で demo_url を持つリポを特定
+      9) config/site-checks.yaml を読んで severity: high のチェック項目を取得
+      10) 各サイトに対して browser ツールでチェック実行:
+        a) browser(open, url) でサイトを開く
+        b) 設定変更 → 生成ボタンクリック → snapshot/screenshot で検証
+        c) ページ数の正確性: 指定枚数(1,5,10)と実際のページ数が一致するか
+        d) 問題の妥当性: ランダム生成された問題が解けるか（math: 負にならない, kanji: 学年範囲内）
+        e) レイアウト: A4に収まるか、余白が適切か
+      11) 問題検出時は reports/latest-health.md の Risks/Blockers に追加 + GitHub Issue 自動作成（type: bugfix）
+
+      == Part 3: Issue Retrospective ==
+      12) monitoring/issue-tracker.jsonl を読む（なければスキップ）
+      13) 各 open Issue を gh issue view で状態確認
+      14) close/merge された Issue の Quality Score を判定（A=merged+未編集, B=merged+編集あり, C=closed without merge）
+      15) monitoring/issue-tracker.jsonl を更新
+      16) レポート末尾に Issue Tracker セクション追加
+
+      17) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
+
+      WhatsApp配信ルール: ステータス変化 or サイトQA問題検出 or Issue Tracker に注目情報があれば配信。
+  - name: focus-task
+    description: Twice-weekly focused single-task suggestion
+    schedule:
+      kind: cron
+      expr: 30 8 * * 1,4
+    timeout_seconds: 1800
+    model: gpt-5.4
+    delivery:
+      mode: none
+      channel: last
+    message: |
+      Focus task: GitHub Issue を作成し、Codex で自動解決して draft PR を作成する。
+
+      == Pre-check ==
+      0) monitoring/issue-tracker.jsonl を読み、以下を判定:
+        a) open な PM作成 Issue が3件以上 → Issue 作成を一時停止。溜まっている Issue のサマリーを返す。
+        b) 動的頻度調整: 直近30日の resolve 率を計算（resolved / total）。
+           - resolve率 50%未満 → 今回は Issue 作成せず、既存 open Issue の優先順位レビューのみ実施。結果を reports/latest-focus.md に記録。
+           - resolve率 50-80% → 最大1 Issue/回に制限。
+           - resolve率 80%以上 → 通常運転（最大2 Issue/回）。feature Issue の比率を上げる。
+        c) 直近4回の focus-task で feature Issue が0件 → 今回は feature を優先的に検討。
+
+      == Issue 作成 ==
+      1) config/repos.yaml の repos: + private_repos: から対象リポを選定。以下を除外:
+        - status: on-hold
+        - status: abandoned
+        - status: dormant（ただし RED 2週連続+high のエスカレーション対象は除外しない）
+      2) monitoring/last-suggested.json を読んで前回提案リポを確認（同じリポは避ける）
+      3) monitoring/health-trend.jsonl を読んでエスカレーション対象（RED 2週連続+high）を最優先
+      4) 対象リポの既存 Issue を確認: gh issue list -R {owner}/{repo} --state open
+        - 重複する内容があれば新規作成しない
+        - 同一リポに PM 作成の open Issue が2件以上あれば新規作成しない
+      5) 各候補リポに scripts/task-suggest + scripts/knowledge-collect を実行
+
+      6) **Dual-Perspective Backlog Generation** — PM視点 と Developer視点 の両方から候補を列挙し、最適な1-2件を選ぶ。
+
+         [PM視点 — Business / Product]
+         対象リポごとに以下を確認し、ユーザー価値起点の候補を洗い出す:
+         - README / 既存機能の棚卸し: 現状の user journey でどこが弱いか
+         - 競合・類似OSSの最新機能: web_search で "{repo category} 2026 features" を検索
+         - 教育系リポ: config/learner-context.yaml の学習段階から逆算した具体スコープ
+         - ユーザーフィードバック: 既存 Issue のコメント、closed Issue の再現要望
+         - 指標: 未達な KPI（使われてない機能、離脱ポイント）
+         候補の型:
+           • feature: 新機能（MVPスコープで切る、競合差別化含む）
+           • improvement: 既存機能の UX / 速度 / エラーメッセージ改善
+           • growth: オンボーディング、告知、SEO、README強化
+
+         [Developer視点 — Tech Health]
+         対象リポごとに以下を調査:
+         - 依存関係の陳腐化: package.json の主要依存（framework / runtime / DB / AI SDK）を npm registry の最新と比較。**メジャー更新が出ているか**を `npm view {pkg} version` 等で確認
+         - CI / Security Scan / Lint の失敗状況: gh run list で直近の失敗を確認
+         - Tech Radar（週次で web_search を行う）: 以下のカテゴリで直近30日の話題を確認
+           · Frontend/Framework: Next.js / React / Vue / Svelte のリリースノート・ブログ
+           · AI/LLM SDK: Anthropic SDK, Vercel AI SDK, MCP spec
+           · DB/ORM: Prisma / Drizzle / Supabase / Postgres
+           · Build/Test: Turbopack / Biome / Vitest / Playwright
+           · Security: npm audit の high/critical
+         - コード臭い: 同じパターンのコピペ、巨大ファイル、未使用依存（`depcheck`系）
+         - Observability のギャップ: error tracking, log, 監視抜け
+         候補の型:
+           • maintenance: 脆弱性修正、CI修復、依存メジャーアップデート
+           • refactor: リファクタ（重複排除、型強化、Server Components化など）
+           • tech-adoption: 新技術の採用（例: Next 16 Cache Components, Turbopack prod, Vercel AI SDK, Prompt Caching, pgvector）
+           • perf: パフォーマンス改善（Lighthouse, bundle size, DB N+1）
+           • dx: 開発者体験（Biome移行、テスト高速化、型安全化）
+
+         [スコアリング — 両視点候補を並べて選ぶ]
+         各候補に以下で 1-10 点を付ける:
+           • Value (ユーザー価値 or 開発効率向上)
+           • Effort (逆スコア: 小さいほど高い)
+           • Confidence (/resolve-issue で自動完走できそうか = 要件の明確さ)
+           • Urgency (セキュリティ / CI failing は +3 のボーナス)
+         合計上位から選定。ただし以下の配分バランスを守る:
+           - 直近4回の focus-task を振り返り、PM視点 と Developer視点 の Issue が 6:4 〜 4:6 の比率に収まるように調整
+           - 連続3回 PM系のみ → 次は Developer系を1件は必ず含む（逆も同様）
+           - 連続3回 tech-adoption が0件 → 新技術評価 Issue を1件混ぜる
+         教育系リポは PM視点優先（子供の学習が主目的）、MCP / ツール系は Developer視点優先。
+
+         tech-adoption Issue の作り方（重要）:
+         - 単に「Xを導入する」ではなく、**なぜ今このリポで導入すると得か** を具体的に（現行の痛み、導入後の改善、移行コスト）
+         - 段階的適用: いきなり全面ではなく、「1ページ / 1モジュールで PoC」「本格移行は別 Issue」に分ける
+         - 互換性リスクを Non-goals / Constraints に明記
+
+      7) AGENTS.md の Issue Creation Standards テンプレートに従って GitHub Issue を作成:
+        gh issue create -R {owner}/{repo} --title '...' --body '...'
+        必須セクション: Problem/Why, Acceptance Criteria, Non-goals, Constraints, Tasks, References
+      8) Pre-check で決定した上限数を超えない。
+
+      == Auto-Resolve（Issue 作成後、1件ずつ逐次実行）==
+      作成した各 Issue に対して以下を実行:
+
+      9) ローカルリポを同期:
+        cd /Users/ken/Developer/private/{repo_name}
+        git fetch origin
+        default_branch=$(gh repo view {owner}/{name} --json defaultBranchRef -q '.defaultBranchRef.name')
+        git checkout $default_branch && git pull origin $default_branch
+
+      10) Codex で Issue を解決:
+        bash /Users/ken/.openclaw/workspace-knishioka-pm/scripts/codex-resolve.sh {owner}/{name} {issue_number}
+        タイムアウト: 15分。失敗した場合は issue-tracker に auto_resolve: failed を記録して次へ。
+
+      11) PR を draft に変換:
+        pr_number=$(gh pr list -R {owner}/{name} --author knishioka --state open --json number,headRefName --jq '.[0].number')
+        gh pr ready --undo -R {owner}/{name} $pr_number 2>/dev/null || true
+
+      == 記録 ==
+      12) monitoring/issue-tracker.jsonl に追記: {repo, issue, type, perspective: "pm"|"dev", subtype: "feature"|"improvement"|"growth"|"maintenance"|"refactor"|"tech-adoption"|"perf"|"dx"|"bugfix", created, status: open, auto_resolve: draft_pr_created or failed, pr: N, playbook_version, lint_available, lint_skipped_reason, verification}
+          - playbook_version / lint_available / lint_skipped_reason は scripts/codex-resolve.sh の起動ログ ([codex-resolve] start ... playbook_version=YYYY-MM-DD lint_available=true|false lint_skipped_reason=... timeout=...s) から `grep -oE` で抽出する
+          - lint_available=false の場合、verification.lint は必ず "n/a" を記録する（Codex 側 PR 本文の動作確認テーブルが ⚠️ n/a になっているはず。なっていなければ補完）
+          - lint_available=true の場合、lint_skipped_reason は null を記録する
+      13) reports/latest-focus.md に以下を記録:
+          - 作成した Issue + PR の一覧（perspective / subtype 付き）
+          - 動的頻度判定結果
+          - 直近4回の perspective 比率（PM:Dev = X:Y）
+          - 今回の Tech Radar スキャンで見つかった重要トピック（採用しなかったが次回以降検討）
+      14) monitoring/last-suggested.json を更新
+      15) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
+
+      == WhatsApp 通知 ==
+      16) draft PR が1件以上作成できた場合のみ、WhatsAppに通知:
+          openclaw message send --channel whatsapp --target +819050822879 --text "$(cat <<'MSG'
+      *🤖 Focus Task — MM/DD*
+      {件数} PR created:
+      • [{repo} #{issue}] {title}
+        → {pr_url}
+      • ...
+      MSG
+      )"
+          PR 0件（resolve失敗のみ or Issue未作成）の場合は通知しない。
+          失敗したものは 末尾に "⚠️ {repo} #{issue}: auto-resolve failed" で追記。
+
+      重要: Issue は /resolve-issue で自動解決できる品質を目指す。Acceptance Criteria は具体的かつ検証可能、Non-goals でスコープを明確に絞り、Constraints で守るべき制約を明記すること。
+      作成した Issue 番号と PR 番号を返す。
+  - name: weekly-knowledge-extract
+    description: Weekly knowledge extraction from personal GitHub repos
+    schedule:
+      kind: cron
+      expr: 0 19 * * 5
+    timeout_seconds: 600
+    delivery:
+      mode: none
+      channel: last
+    message: |
+      Weekly knowledge extraction with competitive research and changelog.
+
+      手順:
+      1) config/repos.yaml の repos: + private_repos: を読んで全リポリストを取得（on-hold は除外）
+      2) monitoring/repo-state.json を読む（前回の抽出タイムスタンプ）
+      3) 各リポに対して scripts/knowledge-collect {owner}/{name} を実行
+      4) 結果を分析し、以下を更新:
+        - knowledge/repos/{name}-kb.md: 技術スタック、アーキテクチャ、主要パターン
+        - knowledge/decisions/{name}-decisions.md: PRやコミットから抽出した設計判断
+      5) 競合・トレンドリサーチ（priority=high のリポのみ、週替わりで1-2リポずつ）:
+        - web_search で類似ツール/ライブラリの最新動向を調査
+        - MCP server なら MCP SDK の最新バージョン・新機能
+        - 教育ツールなら最新の教育技術トレンド
+        - 調査結果を knowledge/repos/{name}-kb.md の Competitive Landscape セクションに追記
+      6) knowledge/STRATEGY.md のルールに従う:
+        - 200行上限、重複排除、ソース日付記載
+      7) knowledge/CHANGELOG.md を生成: 今週の新しい発見のみ記載
+        - 新しい依存関係、設計判断、アーキテクチャ変更
+        - 競合リサーチの発見（新機能候補）
+        - 8週以上 KB が更新されていない priority=high リポがあれば「知識が古い」と警告
+      8) monitoring/repo-state.json を更新
+      9) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
+
+      更新したファイル数と主な発見（特に新機能候補）を簡潔に返す。
+  - name: monthly-portfolio-review
+    description: Monthly portfolio-level review of all repos
+    schedule:
+      kind: cron
+      expr: 0 19 1-7 * 0
+    timeout_seconds: 600
+    delivery:
+      mode: announce
+      channel: whatsapp
+      to: "+819050822879"
+      best_effort: true
+    message: |
+      Monthly portfolio review.
+
+      手順:
+      1) config/repos.yaml の repos: + private_repos: を全て読む
+      2) monitoring/health-trend.jsonl を読んで過去1ヶ月のトレンドを把握
+      3) 全リポを分類:
+        - Active: 30日以内にコミットあり
+        - Dormant: 30-90日
+        - Abandoned: 90日+
+      4) knowledge/repos/*.md を全て読んでクロスリポ分析:
+        - 共通技術・統合機会（例: 複数MCP serverの共通基盤）
+        - 過剰工数のリポ（Issue/PR が多すぎるリポ）
+      5) Abandoned リポ: KB を基にアーカイブ推奨 or 復活条件を提示
+      6) reports/monthly-portfolio-{YYYY-MM}.md に出力
+      7) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
+
+      Private リポも含めてポートフォリオ全体を俯瞰すること。ただし reports/ にはprivateリポの詳細は書かない（名前と分類のみ可）。
+      簡潔なサマリーを返す。
+  - name: private-repo-check
+    description: Bi-weekly health check for private repos (gitignored output only)
+    schedule:
+      kind: cron
+      expr: 0 20 * * 3
+    thinking: low
+    timeout_seconds: 300
+    delivery:
+      mode: none
+      channel: whatsapp
+      to: "+819050822879"
+      best_effort: true
+    message: |
+      Private repo health check.
+
+      重要: このジョブの出力は一切コミットしない。
+
+      手順:
+      1) config/repos.yaml の private_repos: セクションを読む
+      2) status: on-hold のリポは除外
+      3) 各リポに対して scripts/repo-health {owner}/{name} を実行
+      4) 結果を monitoring/private-health.json に書き出す（上書き）
+        フォーマット: [{repo, status, days_inactive, open_issues, ci_status, ...}, ...]
+      5) git add も git commit もしない
+
+      Output Format に従ったサマリーを返す（WhatsApp配信用）。ただしリポの詳細な内容やコードの情報は含めず、名前とステータスのみ。

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -22,6 +22,9 @@
 #     text; `announce` forwards it to `channel`/`to`.
 #   - Changing schedule `expr` reschedules a job. register-cron-jobs.sh edits
 #     the existing job by name so its nextRun/lastRun state is preserved.
+#   - Secrets / PII are referenced as ${ENV_VAR} and resolved at build time, so
+#     this public-repo file stays scrubbed. Currently ${KNISHIOKA_ALERT_TO} (the
+#     WhatsApp alert number). Export it before build / register / verify --live.
 
 schema_version: 1
 defaults:
@@ -34,7 +37,7 @@ defaults:
   failure_alert:
     after: 2
     channel: whatsapp
-    to: "+819050822879"
+    to: "${KNISHIOKA_ALERT_TO}"
     cooldown_ms: 21600000
     mode: announce
     account_id: knishioka-pm
@@ -49,7 +52,7 @@ jobs:
     delivery:
       mode: none
       channel: whatsapp
-      to: "+819050822879"
+      to: "${KNISHIOKA_ALERT_TO}"
       best_effort: true
     message: |
       Weekly repo health check with trend tracking + site QA + Issue retrospective.
@@ -205,7 +208,7 @@ jobs:
 
       == WhatsApp 通知 ==
       16) draft PR が1件以上作成できた場合のみ、WhatsAppに通知:
-          openclaw message send --channel whatsapp --target +819050822879 --text "$(cat <<'MSG'
+          openclaw message send --channel whatsapp --target ${KNISHIOKA_ALERT_TO} --text "$(cat <<'MSG'
       *🤖 Focus Task — MM/DD*
       {件数} PR created:
       • [{repo} #{issue}] {title}
@@ -261,7 +264,7 @@ jobs:
     delivery:
       mode: announce
       channel: whatsapp
-      to: "+819050822879"
+      to: "${KNISHIOKA_ALERT_TO}"
       best_effort: true
     message: |
       Monthly portfolio review.
@@ -292,7 +295,7 @@ jobs:
     delivery:
       mode: none
       channel: whatsapp
-      to: "+819050822879"
+      to: "${KNISHIOKA_ALERT_TO}"
       best_effort: true
     message: |
       Private repo health check.

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -29,9 +29,33 @@
 | `~/.openclaw/cron/jobs.json`       | OpenClaw ランタイムのライブ登録（リポ外）                          | 無視 |
 | `~/.openclaw/cron/jobs-state.json` | nextRun/lastRun 等のランタイム状態（リポ外）                       | 無視 |
 
+## 環境変数（secret / PII）
+
+このリポは **public** なので、電話番号などの機微情報は `jobs.yaml` に直書きせ
+ず `${ENV_VAR}` 参照で持つ。`build-cron-jobs.py` がビルド時に環境変数から解決
+してマニフェストに埋め込むため、git 追跡されるソースは scrub された状態を保つ。
+解決された実値はライブ登録（register 時）に焼き込まれるので、**cron ランタイ
+ム自体に env を設定する必要はない**（build / register / `verify --live` の実行時
+にだけ必要）。
+
+| 変数                 | 用途                               | 例              |
+| -------------------- | ---------------------------------- | --------------- |
+| `KNISHIOKA_ALERT_TO` | WhatsApp 通知 / failure_alert 宛先 | `+81xxxxxxxxxx` |
+
+```bash
+export KNISHIOKA_ALERT_TO='+81...'   # build / register / verify --live の前に
+```
+
+未設定のまま `build` / `register` / `verify --live` を実行すると、`${...}` が未解
+決である旨のエラーで停止する（literal なプレースホルダーを誤登録しない安全装
+置）。`verify --offline` と `build --check` は構造検証のみなので env なしで通る。
+
 ## 変更手順（編集 → 生成 → 検証 → commit）
 
 ```bash
+# 0. secret/PII の env を設定（docs の「環境変数」参照）
+export KNISHIOKA_ALERT_TO='+81...'
+
 # 1. ソースを編集
 $EDITOR config/cron/jobs.yaml
 

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,0 +1,105 @@
+<!-- version: 2026-05-21 (Issue #37) -->
+
+# Cron Job Management
+
+> knishioka-pm の cron ジョブ定義を **git 管理の宣言的ソース** にするための
+> 正本。手で `~/.openclaw/cron/jobs.json` を編集する運用（差分レビュー・履
+> 歴・ロールバック不能、`jobs.json.bak.*` の散乱）をやめ、`config/cron/jobs.yaml`
+> を編集 → 生成 → 検証 → commit のフローに統一する。ds-pm ワークスペースの
+> 同等の仕組みを移植・調整したもの。
+
+## なぜこうするか
+
+- `~/.openclaw/cron/jobs.json` は OpenClaw ランタイムの状態ファイルで、git
+  管理されていない。手編集は履歴も差分レビューもなく壊れやすい（公式ドキュメ
+  ントも「`jobs.json` は git、`jobs-state.json` は gitignore」を推奨）。
+- このリポでは **`config/cron/jobs.yaml` が唯一の source-of-truth**。ここを
+  PR で変更すればレビュー可能になり、ライブ登録内容との差分（drift）も検出で
+  きる。
+
+## ファイル構成
+
+| パス                               | 役割                                                               | git  |
+| ---------------------------------- | ------------------------------------------------------------------ | ---- |
+| `config/cron/jobs.yaml`            | 宣言的ソース（5 ジョブ）。**編集するのはここだけ**                 | 追跡 |
+| `scripts/build-cron-jobs.py`       | jobs.yaml → `build/cron/manifest.json` を生成（message_hash 付き） | 追跡 |
+| `scripts/verify-cron-playbooks.sh` | manifest とライブ登録内容を比較し drift を検出（読み取り専用）     | 追跡 |
+| `scripts/register-cron-jobs.sh`    | manifest をライブに適用。**既存ジョブは id を保ったまま edit**     | 追跡 |
+| `build/cron/manifest.json`         | 生成物（gitignore 済み）                                           | 無視 |
+| `~/.openclaw/cron/jobs.json`       | OpenClaw ランタイムのライブ登録（リポ外）                          | 無視 |
+| `~/.openclaw/cron/jobs-state.json` | nextRun/lastRun 等のランタイム状態（リポ外）                       | 無視 |
+
+## 変更手順（編集 → 生成 → 検証 → commit）
+
+```bash
+# 1. ソースを編集
+$EDITOR config/cron/jobs.yaml
+
+# 2. マニフェストを再生成
+scripts/build-cron-jobs.py            # → build/cron/manifest.json
+
+# 3. ライブ登録との差分を確認（何も変更しない）
+scripts/verify-cron-playbooks.sh --live
+
+# 4. ライブに適用（既存ジョブは id・state を保持したまま更新）
+scripts/register-cron-jobs.sh --dry-run   # まず計画を確認
+scripts/register-cron-jobs.sh             # 適用
+
+# 5. 適用後、再度 drift ゼロを確認してから commit
+scripts/verify-cron-playbooks.sh --live
+git add config/cron/jobs.yaml && git commit
+```
+
+> **AGENTS.md 準拠:** `scripts/*` と本ワークスペースの構成ファイルの追加・変
+> 更は cron / 自動セッションからは不可。Ken との対話 or 明示承認下でのみ行う。
+
+## state を壊さない設計（schedule-identity）
+
+`scripts/register-cron-jobs.sh` は ds-pm 版の「rm して add し直す」方式を採
+らない。rm+add は新しい job id を発番し、`nextRun` / `lastRun` /
+`consecutiveErrors` がリセットされてしまうため。代わりに **ライブジョブを名
+前で突き合わせ、`openclaw cron edit <id>` で in-place 更新**する。新規ジョブ
+だけが `openclaw cron add` で作られ、既存ジョブが削除されることはない。これ
+により Issue #37 の制約「既存ジョブの state を破壊しない / schedule-identity
+を変えない」を満たす。
+
+## jobs.yaml スキーマ
+
+```yaml
+schema_version: 1
+defaults: # 全ジョブ共通。各ジョブのキーで個別に上書き可
+  agent_id: knishioka-pm
+  tz: Asia/Kuala_Lumpur
+  enabled: true
+  session_target: isolated
+  wake_mode: now
+  thinking: medium
+  failure_alert:
+    { after, channel, to, cooldown_ms, mode, account_id, best_effort }
+jobs:
+  - name: weekly-repo-health
+    description: ...
+    schedule: { kind: cron, expr: "0 20 * * 0" } # tz は defaults から
+    timeout_seconds: 900 # ジョブ固有
+    delivery: { mode: none, channel: whatsapp, to: "+81...", best_effort: true }
+    message: | # 完全なエージェントプロンプト（drift checker がハッシュ照合）
+      ...
+```
+
+- `message` は knishioka ジョブの全プロンプト（別ファイルの playbook は持た
+  ない）。一字一句が `message_hash` に効くので、改行・空白も含めてそのまま保
+  持する。
+- `delivery.mode: none` はジョブ完了テキストを fallback 配信しない。`announce`
+  は `channel` / `to` へ転送する。
+- `model` は省略時エージェント既定。`thinking` は省略時 `defaults.thinking`。
+
+## ドリフト検出のモード
+
+| コマンド                                     | 用途                                                          |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| `verify-cron-playbooks.sh --live`            | ライブ登録（`openclaw cron list`）と manifest を比較。既定    |
+| `verify-cron-playbooks.sh --offline`         | openclaw を呼ばず jobs.yaml がビルドできるかだけ確認（CI 用） |
+| `verify-cron-playbooks.sh --snapshot <path>` | 記録済み JSON スナップショットと比較                          |
+
+CI（`.github/workflows/check.yml`）は `--offline`（+ PyYAML）で
+`config/cron/jobs.yaml` が常にビルド可能であることを保証する。

--- a/scripts/build-cron-jobs.py
+++ b/scripts/build-cron-jobs.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Build the canonical cron job manifest for knishioka-pm.
+
+Reads ``config/cron/jobs.yaml`` (the source-of-truth for this workspace's
+cron jobs) and emits a JSON manifest that ``scripts/register-cron-jobs.sh``
+consumes when calling ``openclaw cron edit`` / ``openclaw cron add``.
+
+The manifest is also what ``scripts/verify-cron-playbooks.sh`` compares
+against the live ``openclaw cron list --json`` output, so committing
+``config/cron/jobs.yaml`` makes every cron change reviewable in a PR and
+detectable as drift if the live registry diverges.
+
+Adapted from the ds-pm workspace (``~/.openclaw/workspace-ds-pm``). Unlike
+ds-pm, knishioka-pm has no per-project templates and no playbook files: all
+jobs are singletons whose full prompt lives inline in ``message``. Each job
+carries per-job ``delivery`` and payload metadata (``thinking``,
+``timeout_seconds``, ``model``) because these differ across the 5 jobs.
+A ``playbook`` field is still supported (optional) for forward-compat.
+
+Output (default ``build/cron/manifest.json``):
+
+    {
+      "schema_version": 1,
+      "generated_from": "config/cron/jobs.yaml",
+      "playbook_hashes": {},
+      "jobs": [
+        {
+          "name": "weekly-repo-health",
+          "description": "...",
+          "agent_id": "knishioka-pm",
+          "schedule": {"kind": "cron", "expr": "0 20 * * 0", "tz": "Asia/Kuala_Lumpur"},
+          "session_target": "isolated",
+          "wake_mode": "now",
+          "thinking": "medium",
+          "timeout_seconds": 900,
+          "model": null,
+          "delivery": {"mode": "none", "channel": "whatsapp", "to": "+81...", "best_effort": true},
+          "playbook": null,
+          "message": "...",
+          "message_hash": "<sha256 of rstripped message>",
+          "failure_alert": {...},
+          "enabled": true
+        },
+        ...
+      ]
+    }
+
+Usage:
+    scripts/build-cron-jobs.py                # writes build/cron/manifest.json
+    scripts/build-cron-jobs.py --output -     # writes JSON to stdout
+    scripts/build-cron-jobs.py --check        # just expand and validate, no write
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_yaml(path: Path) -> Any:
+    """Load YAML using PyYAML if available, else fall back to ``uv run`` shim.
+
+    CI installs PyYAML directly (``import yaml`` path). Locally, where PyYAML
+    may not be on the interpreter, we shell out to ``uv run --with pyyaml``
+    the same way the workspace's other Python tools do.
+    """
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        return yaml.safe_load(path.read_text())
+    except ModuleNotFoundError:
+        import subprocess
+
+        out = subprocess.check_output(
+            [
+                "uv",
+                "run",
+                "--quiet",
+                "--with",
+                "pyyaml",
+                "python3",
+                "-c",
+                "import sys, yaml, json;"
+                "print(json.dumps(yaml.safe_load(open(sys.argv[1]).read())))",
+                str(path),
+            ],
+            text=True,
+        )
+        return json.loads(out)
+
+
+def _sha256(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _normalize_delivery(delivery: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize a job's delivery block to a canonical shape.
+
+    ``mode`` is required (``none`` or ``announce``). ``channel`` defaults to
+    ``last`` to mirror the ``openclaw cron add`` default. ``to`` and
+    ``best_effort`` are optional and omitted when absent so the manifest only
+    carries fields that were actually declared.
+    """
+    delivery = delivery or {}
+    mode = delivery.get("mode", "none")
+    if mode not in ("none", "announce"):
+        raise SystemExit(
+            f"build-cron-jobs: invalid delivery.mode {mode!r} (want none|announce)"
+        )
+    out: dict[str, Any] = {"mode": mode, "channel": delivery.get("channel", "last")}
+    if "to" in delivery and delivery["to"] is not None:
+        out["to"] = delivery["to"]
+    if "best_effort" in delivery and delivery["best_effort"] is not None:
+        out["best_effort"] = bool(delivery["best_effort"])
+    return out
+
+
+def _normalize_failure_alert(fa: dict[str, Any]) -> dict[str, Any]:
+    """Pass the failure_alert block through with a stable key order."""
+    out = {
+        "after": fa["after"],
+        "channel": fa["channel"],
+        "to": fa["to"],
+        "cooldown_ms": fa["cooldown_ms"],
+        "mode": fa["mode"],
+        "account_id": fa["account_id"],
+    }
+    if "best_effort" in fa and fa["best_effort"] is not None:
+        out["best_effort"] = bool(fa["best_effort"])
+    return out
+
+
+def _normalize_job(job: dict[str, Any], defaults: dict[str, Any]) -> dict[str, Any]:
+    schedule = dict(job["schedule"])
+    if schedule.get("kind") == "cron" and "tz" not in schedule:
+        schedule["tz"] = defaults["tz"]
+    message = job["message"].rstrip()
+    return {
+        "name": job["name"],
+        "description": job.get("description", ""),
+        "agent_id": defaults["agent_id"],
+        "schedule": schedule,
+        "session_target": job.get("session_target", defaults["session_target"]),
+        "wake_mode": job.get("wake_mode", defaults["wake_mode"]),
+        "thinking": job.get("thinking", defaults.get("thinking")),
+        "timeout_seconds": job.get("timeout_seconds"),
+        "model": job.get("model"),
+        "delivery": _normalize_delivery(job.get("delivery")),
+        "playbook": job.get("playbook"),
+        "message": message,
+        "message_hash": _sha256(message),
+        "failure_alert": _normalize_failure_alert(defaults["failure_alert"]),
+        "enabled": job.get("enabled", defaults["enabled"]),
+    }
+
+
+def build(workspace_root: Path, jobs_yaml_path: Path) -> dict[str, Any]:
+    spec = _load_yaml(jobs_yaml_path)
+    if spec.get("schema_version") != 1:
+        raise SystemExit(
+            f"build-cron-jobs: unsupported schema_version "
+            f"{spec.get('schema_version')!r} in {jobs_yaml_path}"
+        )
+    defaults = spec.get("defaults") or {}
+    for required in (
+        "agent_id",
+        "tz",
+        "enabled",
+        "session_target",
+        "wake_mode",
+        "failure_alert",
+    ):
+        if required not in defaults:
+            raise SystemExit(
+                f"build-cron-jobs: missing required default '{required}' in {jobs_yaml_path}"
+            )
+
+    expanded: list[dict[str, Any]] = []
+    playbook_paths: set[str] = set()
+    for job in spec.get("jobs") or []:
+        expanded.append(_normalize_job(job, defaults))
+        if job.get("playbook"):
+            playbook_paths.add(job["playbook"])
+
+    # Playbook hashes (knishioka jobs are inline today, so this is usually
+    # empty — kept for parity with ds-pm so a future playbook reference is
+    # automatically drift-checked).
+    playbook_hashes: dict[str, str] = {}
+    for rel in sorted(playbook_paths):
+        pb_path = workspace_root / rel
+        if not pb_path.is_file():
+            raise SystemExit(
+                f"build-cron-jobs: referenced playbook not found: {rel} (resolved to {pb_path})"
+            )
+        playbook_hashes[rel] = _sha256(pb_path.read_text())
+    for job in expanded:
+        pb = job.get("playbook")
+        if pb:
+            job["playbook_hash"] = playbook_hashes[pb]
+
+    # Sanity: detect duplicate names.
+    seen: dict[str, int] = {}
+    for job in expanded:
+        seen[job["name"]] = seen.get(job["name"], 0) + 1
+    dups = sorted(name for name, count in seen.items() if count > 1)
+    if dups:
+        raise SystemExit(f"build-cron-jobs: duplicate job names produced: {dups}")
+
+    try:
+        generated_from = str(jobs_yaml_path.relative_to(workspace_root))
+    except ValueError:
+        generated_from = str(jobs_yaml_path)
+
+    return {
+        "schema_version": 1,
+        "generated_from": generated_from,
+        "playbook_hashes": playbook_hashes,
+        "jobs": expanded,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the canonical knishioka-pm cron manifest"
+    )
+    parser.add_argument(
+        "--input",
+        default=None,
+        help="Path to jobs.yaml (default: <workspace>/config/cron/jobs.yaml)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Path to write manifest JSON. "
+            "Use '-' for stdout. Default: <workspace>/build/cron/manifest.json"
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate and expand without writing output",
+    )
+    args = parser.parse_args(argv)
+
+    # Detect workspace root: nearest ancestor containing config/cron/jobs.yaml.
+    here = Path(__file__).resolve()
+    for cand in (here.parent.parent, *here.parents):
+        if (cand / "config" / "cron" / "jobs.yaml").is_file():
+            workspace_root = cand
+            break
+    else:
+        raise SystemExit("build-cron-jobs: cannot locate workspace root")
+
+    jobs_yaml = (
+        Path(args.input).resolve()
+        if args.input
+        else workspace_root / "config" / "cron" / "jobs.yaml"
+    )
+    manifest = build(workspace_root, jobs_yaml)
+
+    if args.check:
+        sys.stderr.write(
+            f"build-cron-jobs: OK ({len(manifest['jobs'])} jobs, "
+            f"{len(manifest['playbook_hashes'])} playbooks)\n"
+        )
+        return 0
+
+    out_target = (
+        Path(args.output).resolve()
+        if (args.output and args.output != "-")
+        else (
+            None
+            if args.output == "-"
+            else workspace_root / "build" / "cron" / "manifest.json"
+        )
+    )
+
+    payload = json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
+    if out_target is None:
+        sys.stdout.write(payload)
+    else:
+        out_target.parent.mkdir(parents=True, exist_ok=True)
+        out_target.write_text(payload)
+        try:
+            display = out_target.relative_to(workspace_root)
+        except ValueError:
+            display = out_target
+        sys.stderr.write(
+            f"build-cron-jobs: wrote {len(manifest['jobs'])} jobs to {display}\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build-cron-jobs.py
+++ b/scripts/build-cron-jobs.py
@@ -56,6 +56,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -97,7 +99,37 @@ def _sha256(data: str) -> str:
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
-def _normalize_delivery(delivery: dict[str, Any] | None) -> dict[str, Any]:
+_ENV_REF = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
+
+
+def _expand_env(value: Any, unresolved: set[str]) -> Any:
+    """Substitute ``${NAME}`` references from the environment.
+
+    Secrets / PII (e.g. the WhatsApp alert number) live in the environment, not
+    in the committed ``config/cron/jobs.yaml`` (this repo is public). At build
+    time we resolve them so the manifest the registry consumes carries the real
+    value, while the source-of-truth stays scrubbed.
+
+    Names that are not set in the environment are left as the literal
+    ``${NAME}`` and recorded in ``unresolved`` so the caller can decide whether
+    that is fatal (apply / live verify) or acceptable (offline structural check).
+    """
+    if not isinstance(value, str):
+        return value
+
+    def _sub(m: "re.Match[str]") -> str:
+        name = m.group(1)
+        if name in os.environ:
+            return os.environ[name]
+        unresolved.add(name)
+        return m.group(0)
+
+    return _ENV_REF.sub(_sub, value)
+
+
+def _normalize_delivery(
+    delivery: dict[str, Any] | None, unresolved: set[str]
+) -> dict[str, Any]:
     """Normalize a job's delivery block to a canonical shape.
 
     ``mode`` is required (``none`` or ``announce``). ``channel`` defaults to
@@ -113,18 +145,20 @@ def _normalize_delivery(delivery: dict[str, Any] | None) -> dict[str, Any]:
         )
     out: dict[str, Any] = {"mode": mode, "channel": delivery.get("channel", "last")}
     if "to" in delivery and delivery["to"] is not None:
-        out["to"] = delivery["to"]
+        out["to"] = _expand_env(delivery["to"], unresolved)
     if "best_effort" in delivery and delivery["best_effort"] is not None:
         out["best_effort"] = bool(delivery["best_effort"])
     return out
 
 
-def _normalize_failure_alert(fa: dict[str, Any]) -> dict[str, Any]:
+def _normalize_failure_alert(
+    fa: dict[str, Any], unresolved: set[str]
+) -> dict[str, Any]:
     """Pass the failure_alert block through with a stable key order."""
     out = {
         "after": fa["after"],
         "channel": fa["channel"],
-        "to": fa["to"],
+        "to": _expand_env(fa["to"], unresolved),
         "cooldown_ms": fa["cooldown_ms"],
         "mode": fa["mode"],
         "account_id": fa["account_id"],
@@ -134,11 +168,13 @@ def _normalize_failure_alert(fa: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _normalize_job(job: dict[str, Any], defaults: dict[str, Any]) -> dict[str, Any]:
+def _normalize_job(
+    job: dict[str, Any], defaults: dict[str, Any], unresolved: set[str]
+) -> dict[str, Any]:
     schedule = dict(job["schedule"])
     if schedule.get("kind") == "cron" and "tz" not in schedule:
         schedule["tz"] = defaults["tz"]
-    message = job["message"].rstrip()
+    message = _expand_env(job["message"], unresolved).rstrip()
     return {
         "name": job["name"],
         "description": job.get("description", ""),
@@ -149,16 +185,20 @@ def _normalize_job(job: dict[str, Any], defaults: dict[str, Any]) -> dict[str, A
         "thinking": job.get("thinking", defaults.get("thinking")),
         "timeout_seconds": job.get("timeout_seconds"),
         "model": job.get("model"),
-        "delivery": _normalize_delivery(job.get("delivery")),
+        "delivery": _normalize_delivery(job.get("delivery"), unresolved),
         "playbook": job.get("playbook"),
         "message": message,
         "message_hash": _sha256(message),
-        "failure_alert": _normalize_failure_alert(defaults["failure_alert"]),
+        "failure_alert": _normalize_failure_alert(
+            defaults["failure_alert"], unresolved
+        ),
         "enabled": job.get("enabled", defaults["enabled"]),
     }
 
 
-def build(workspace_root: Path, jobs_yaml_path: Path) -> dict[str, Any]:
+def build(
+    workspace_root: Path, jobs_yaml_path: Path, allow_unset_env: bool = False
+) -> dict[str, Any]:
     spec = _load_yaml(jobs_yaml_path)
     if spec.get("schema_version") != 1:
         raise SystemExit(
@@ -179,12 +219,25 @@ def build(workspace_root: Path, jobs_yaml_path: Path) -> dict[str, Any]:
                 f"build-cron-jobs: missing required default '{required}' in {jobs_yaml_path}"
             )
 
+    unresolved: set[str] = set()
     expanded: list[dict[str, Any]] = []
     playbook_paths: set[str] = set()
     for job in spec.get("jobs") or []:
-        expanded.append(_normalize_job(job, defaults))
+        expanded.append(_normalize_job(job, defaults, unresolved))
         if job.get("playbook"):
             playbook_paths.add(job["playbook"])
+
+    # ${ENV} references (e.g. the WhatsApp alert number) must resolve before the
+    # manifest is applied to or compared against the live registry. Offline /
+    # structural checks tolerate unset vars (allow_unset_env=True).
+    if unresolved and not allow_unset_env:
+        names = ", ".join(sorted(unresolved))
+        raise SystemExit(
+            f"build-cron-jobs: unset environment variable(s) referenced in "
+            f"{jobs_yaml_path.name}: {names}\n"
+            f"  export them before build/register/verify --live, "
+            f"or pass --allow-unset-env for a structural-only build."
+        )
 
     # Playbook hashes (knishioka jobs are inline today, so this is usually
     # empty — kept for parity with ds-pm so a future playbook reference is
@@ -219,6 +272,7 @@ def build(workspace_root: Path, jobs_yaml_path: Path) -> dict[str, Any]:
         "schema_version": 1,
         "generated_from": generated_from,
         "playbook_hashes": playbook_hashes,
+        "unresolved_env": sorted(unresolved),
         "jobs": expanded,
     }
 
@@ -243,7 +297,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Validate and expand without writing output",
+        help="Validate and expand without writing output (implies --allow-unset-env)",
+    )
+    parser.add_argument(
+        "--allow-unset-env",
+        action="store_true",
+        help="Do not fail on unset ${ENV} references (structural-only build)",
     )
     args = parser.parse_args(argv)
 
@@ -261,7 +320,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.input
         else workspace_root / "config" / "cron" / "jobs.yaml"
     )
-    manifest = build(workspace_root, jobs_yaml)
+    manifest = build(
+        workspace_root, jobs_yaml, allow_unset_env=(args.allow_unset_env or args.check)
+    )
 
     if args.check:
         sys.stderr.write(

--- a/scripts/register-cron-jobs.sh
+++ b/scripts/register-cron-jobs.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Apply the canonical cron manifest (build/cron/manifest.json) to the local
+# openclaw cron registry for the knishioka-pm agent.
+#
+# STATE-PRESERVING: unlike the ds-pm register script (which rm's + re-add's),
+# this matches manifest jobs to live jobs BY NAME and patches them in place
+# with `openclaw cron edit <id>`. Editing keeps the job id, so nextRun /
+# lastRun / consecutiveErrors state is preserved (Issue #37 constraint:
+# "既存ジョブの state を破壊しない / schedule-identity を変えない"). Only jobs
+# that do not yet exist are created with `openclaw cron add`. Existing jobs are
+# never removed.
+#
+# Usage:
+#   scripts/register-cron-jobs.sh                      # apply default manifest
+#   scripts/register-cron-jobs.sh --manifest <path>    # apply alternate manifest
+#   scripts/register-cron-jobs.sh --dry-run            # print plan, change nothing
+#
+# Exit codes:
+#   0  success (or no-op when --dry-run)
+#   1  invalid CLI / manifest
+#   2  one or more openclaw operations failed
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENT_ID="knishioka-pm"
+MANIFEST="${WORKSPACE_ROOT}/build/cron/manifest.json"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "register-cron-jobs: unknown arg '$1'" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "register-cron-jobs: manifest not found at $MANIFEST" >&2
+  echo "  Run scripts/build-cron-jobs.py first (or pass --manifest <path>)" >&2
+  exit 1
+fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "register-cron-jobs: 'openclaw' CLI not on PATH" >&2
+  exit 1
+fi
+
+# Manifest job names.
+mapfile -t MANIFEST_NAMES < <(python3 -c "import json,sys;print('\n'.join(j['name'] for j in json.load(open(sys.argv[1]))['jobs']))" "$MANIFEST")
+if [[ ${#MANIFEST_NAMES[@]} -eq 0 ]]; then
+  echo "register-cron-jobs: manifest has zero jobs" >&2
+  exit 1
+fi
+
+# Live knishioka-pm jobs: name -> id.
+REGISTERED_JSON="$(openclaw cron list --json)"
+declare -A REGISTERED_BY_NAME
+while IFS=$'\t' read -r jname jid; do
+  [[ -n "$jname" ]] && REGISTERED_BY_NAME["$jname"]="$jid"
+done < <(printf '%s' "$REGISTERED_JSON" | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for j in data.get('jobs',[]):
+    if j.get('agentId')=='$AGENT_ID':
+        print(f\"{j['name']}\t{j['id']}\")
+")
+
+# Report any live jobs not in the manifest (informational; never removed).
+EXTRA=()
+for name in "${!REGISTERED_BY_NAME[@]}"; do
+  if ! printf '%s\n' "${MANIFEST_NAMES[@]}" | grep -Fxq -- "$name"; then
+    EXTRA+=("$name")
+  fi
+done
+
+echo "register-cron-jobs: manifest jobs    = ${#MANIFEST_NAMES[@]}"
+echo "register-cron-jobs: live ${AGENT_ID}  = ${#REGISTERED_BY_NAME[@]}"
+echo "register-cron-jobs: extras (kept)    = ${#EXTRA[@]}"
+echo "register-cron-jobs: mode             = $([[ $DRY_RUN -eq 1 ]] && echo DRY-RUN || echo APPLY)"
+if [[ ${#EXTRA[@]} -gt 0 ]]; then
+  printf '  [extra-not-touched] %s\n' "${EXTRA[@]}"
+fi
+echo
+
+# Emit the openclaw flag argv (NUL-delimited) for a manifest job. NUL framing
+# is required because messages contain newlines, '$', and CJK text that would
+# break eval/word-splitting. The leading subcommand (add) or id (edit) is added
+# by the caller, not here.
+emit_args() {
+  local name="$1"
+  MANIFEST="$MANIFEST" JOB_NAME="$name" python3 <<'PY'
+import json, os, sys
+
+manifest = json.load(open(os.environ["MANIFEST"]))
+name = os.environ["JOB_NAME"]
+job = next(j for j in manifest["jobs"] if j["name"] == name)
+
+args = [
+    "--agent", job["agent_id"],
+    "--name", job["name"],
+    "--description", job.get("description", ""),
+    "--session", job["session_target"],
+    "--wake", job["wake_mode"],
+    "--message", job["message"],
+]
+
+sched = job["schedule"]
+if sched.get("kind") == "cron":
+    args += ["--cron", sched["expr"]]
+    if sched.get("tz"):
+        args += ["--tz", sched["tz"]]
+elif sched.get("kind") == "every":
+    secs = int(sched["every_ms"] / 1000)
+    args += ["--every", f"{secs}s"]
+
+# Payload metadata.
+if job.get("thinking"):
+    args += ["--thinking", str(job["thinking"])]
+if job.get("timeout_seconds") is not None:
+    args += ["--timeout-seconds", str(job["timeout_seconds"])]
+if job.get("model"):
+    args += ["--model", str(job["model"])]
+
+# Delivery.
+d = job.get("delivery") or {}
+if d.get("channel"):
+    args += ["--channel", d["channel"]]
+if d.get("to"):
+    args += ["--to", d["to"]]
+if d.get("best_effort"):
+    args += ["--best-effort-deliver"]
+if d.get("mode") == "announce":
+    args += ["--announce"]
+else:
+    args += ["--no-deliver"]
+
+# Failure alert.
+fa = job.get("failure_alert") or {}
+if fa:
+    ms = int(fa.get("cooldown_ms", 0))
+    if ms and ms % 3600000 == 0:
+        cooldown = f"{ms // 3600000}h"
+    elif ms and ms % 60000 == 0:
+        cooldown = f"{ms // 60000}m"
+    else:
+        cooldown = f"{ms // 1000}s"
+    args += [
+        "--failure-alert",
+        "--failure-alert-after", str(fa["after"]),
+        "--failure-alert-channel", fa["channel"],
+        "--failure-alert-to", fa["to"],
+        "--failure-alert-cooldown", cooldown,
+        "--failure-alert-mode", fa["mode"],
+        "--failure-alert-account-id", fa["account_id"],
+    ]
+
+sys.stdout.write("\0".join(args))
+PY
+}
+
+FAILED=()
+for name in "${MANIFEST_NAMES[@]}"; do
+  mapfile -d '' -t args < <(emit_args "$name")
+  id="${REGISTERED_BY_NAME[$name]:-}"
+
+  if [[ -n "$id" ]]; then
+    # Existing job: patch in place (preserves state). Ensure enabled state.
+    enable_flag="--enable"
+    op=(openclaw cron edit "$id" "$enable_flag" "${args[@]}")
+  else
+    # New job: create.
+    op=(openclaw cron add "${args[@]}")
+  fi
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    printf '+'; printf ' %q' "${op[@]}"; printf '\n'
+  else
+    if ! "${op[@]}" >/dev/null; then
+      FAILED+=("$name")
+    else
+      echo "register-cron-jobs: $([[ -n "$id" ]] && echo edited || echo added) $name"
+    fi
+  fi
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "register-cron-jobs: FAIL on ${#FAILED[@]} job(s):" >&2
+  printf '  - %s\n' "${FAILED[@]}" >&2
+  exit 2
+fi
+
+echo "register-cron-jobs: $([[ $DRY_RUN -eq 1 ]] && echo DRY-RUN done || echo applied) ${#MANIFEST_NAMES[@]} jobs"

--- a/scripts/register-cron-jobs.sh
+++ b/scripts/register-cron-jobs.sh
@@ -46,6 +46,16 @@ if ! command -v openclaw >/dev/null 2>&1; then
   exit 1
 fi
 
+# Refuse to apply a manifest with unresolved ${ENV} references — that would
+# register a literal "${KNISHIOKA_ALERT_TO}" as a delivery target. Rebuild with
+# the env var exported (see docs/cron.md).
+UNRESOLVED="$(python3 -c "import json,sys;print(','.join(json.load(open(sys.argv[1])).get('unresolved_env') or []))" "$MANIFEST")"
+if [[ -n "$UNRESOLVED" ]]; then
+  echo "register-cron-jobs: manifest has unresolved env var(s): $UNRESOLVED" >&2
+  echo "  export them and re-run scripts/build-cron-jobs.py before registering" >&2
+  exit 1
+fi
+
 # Manifest job names.
 mapfile -t MANIFEST_NAMES < <(python3 -c "import json,sys;print('\n'.join(j['name'] for j in json.load(open(sys.argv[1]))['jobs']))" "$MANIFEST")
 if [[ ${#MANIFEST_NAMES[@]} -eq 0 ]]; then
@@ -83,94 +93,113 @@ if [[ ${#EXTRA[@]} -gt 0 ]]; then
 fi
 echo
 
-# Emit the openclaw flag argv (NUL-delimited) for a manifest job. NUL framing
-# is required because messages contain newlines, '$', and CJK text that would
-# break eval/word-splitting. The leading subcommand (add) or id (edit) is added
-# by the caller, not here.
-emit_args() {
-  local name="$1"
-  MANIFEST="$MANIFEST" JOB_NAME="$name" python3 <<'PY'
+# Emit the openclaw flag argv for EVERY job in a single python invocation
+# (manifest parsed once). NUL framing is required because messages contain
+# newlines, '$', and CJK text that would break eval/word-splitting.
+#
+# Stream layout per job: name, enabled("1"/"0"), argc, then <argc> flag tokens
+# — all NUL-delimited. The count prefix lets bash slice each job's args back
+# out unambiguously even though the args themselves may contain any byte except
+# NUL. The leading subcommand (add) or id (edit) and the enable/disable flag are
+# added by the bash caller, which is the side that knows whether the job exists.
+emit_all_args() {
+  MANIFEST="$MANIFEST" python3 <<'PY'
 import json, os, sys
 
 manifest = json.load(open(os.environ["MANIFEST"]))
-name = os.environ["JOB_NAME"]
-job = next(j for j in manifest["jobs"] if j["name"] == name)
+out = []
 
-args = [
-    "--agent", job["agent_id"],
-    "--name", job["name"],
-    "--description", job.get("description", ""),
-    "--session", job["session_target"],
-    "--wake", job["wake_mode"],
-    "--message", job["message"],
-]
-
-sched = job["schedule"]
-if sched.get("kind") == "cron":
-    args += ["--cron", sched["expr"]]
-    if sched.get("tz"):
-        args += ["--tz", sched["tz"]]
-elif sched.get("kind") == "every":
-    secs = int(sched["every_ms"] / 1000)
-    args += ["--every", f"{secs}s"]
-
-# Payload metadata.
-if job.get("thinking"):
-    args += ["--thinking", str(job["thinking"])]
-if job.get("timeout_seconds") is not None:
-    args += ["--timeout-seconds", str(job["timeout_seconds"])]
-if job.get("model"):
-    args += ["--model", str(job["model"])]
-
-# Delivery.
-d = job.get("delivery") or {}
-if d.get("channel"):
-    args += ["--channel", d["channel"]]
-if d.get("to"):
-    args += ["--to", d["to"]]
-if d.get("best_effort"):
-    args += ["--best-effort-deliver"]
-if d.get("mode") == "announce":
-    args += ["--announce"]
-else:
-    args += ["--no-deliver"]
-
-# Failure alert.
-fa = job.get("failure_alert") or {}
-if fa:
-    ms = int(fa.get("cooldown_ms", 0))
-    if ms and ms % 3600000 == 0:
-        cooldown = f"{ms // 3600000}h"
-    elif ms and ms % 60000 == 0:
-        cooldown = f"{ms // 60000}m"
-    else:
-        cooldown = f"{ms // 1000}s"
-    args += [
-        "--failure-alert",
-        "--failure-alert-after", str(fa["after"]),
-        "--failure-alert-channel", fa["channel"],
-        "--failure-alert-to", fa["to"],
-        "--failure-alert-cooldown", cooldown,
-        "--failure-alert-mode", fa["mode"],
-        "--failure-alert-account-id", fa["account_id"],
+for job in manifest["jobs"]:
+    args = [
+        "--agent", job["agent_id"],
+        "--name", job["name"],
+        "--description", job.get("description", ""),
+        "--session", job["session_target"],
+        "--wake", job["wake_mode"],
+        "--message", job["message"],
     ]
 
-sys.stdout.write("\0".join(args))
+    sched = job["schedule"]
+    if sched.get("kind") == "cron":
+        args += ["--cron", sched["expr"]]
+        if sched.get("tz"):
+            args += ["--tz", sched["tz"]]
+    elif sched.get("kind") == "every":
+        secs = int(sched["every_ms"] / 1000)
+        args += ["--every", f"{secs}s"]
+
+    # Payload metadata.
+    if job.get("thinking"):
+        args += ["--thinking", str(job["thinking"])]
+    if job.get("timeout_seconds") is not None:
+        args += ["--timeout-seconds", str(job["timeout_seconds"])]
+    if job.get("model"):
+        args += ["--model", str(job["model"])]
+
+    # Delivery.
+    d = job.get("delivery") or {}
+    if d.get("channel"):
+        args += ["--channel", d["channel"]]
+    if d.get("to"):
+        args += ["--to", d["to"]]
+    if d.get("best_effort"):
+        args += ["--best-effort-deliver"]
+    if d.get("mode") == "announce":
+        args += ["--announce"]
+    else:
+        args += ["--no-deliver"]
+
+    # Failure alert.
+    fa = job.get("failure_alert") or {}
+    if fa:
+        ms = int(fa.get("cooldown_ms", 0))
+        if ms and ms % 3600000 == 0:
+            cooldown = f"{ms // 3600000}h"
+        elif ms and ms % 60000 == 0:
+            cooldown = f"{ms // 60000}m"
+        else:
+            cooldown = f"{ms // 1000}s"
+        args += [
+            "--failure-alert",
+            "--failure-alert-after", str(fa["after"]),
+            "--failure-alert-channel", fa["channel"],
+            "--failure-alert-to", fa["to"],
+            "--failure-alert-cooldown", cooldown,
+            "--failure-alert-mode", fa["mode"],
+            "--failure-alert-account-id", fa["account_id"],
+        ]
+
+    out.append(job["name"])
+    out.append("1" if job.get("enabled", True) else "0")
+    out.append(str(len(args)))
+    out.extend(args)
+
+sys.stdout.write("\0".join(out))
 PY
 }
 
+# Read the whole stream once, then walk it record by record.
+mapfile -d '' -t TOKENS < <(emit_all_args)
+
 FAILED=()
-for name in "${MANIFEST_NAMES[@]}"; do
-  mapfile -d '' -t args < <(emit_args "$name")
+i=0
+while (( i < ${#TOKENS[@]} )); do
+  name="${TOKENS[i]}"; ((i += 1))
+  enabled="${TOKENS[i]}"; ((i += 1))
+  argc="${TOKENS[i]}"; ((i += 1))
+  args=("${TOKENS[@]:i:argc}"); ((i += argc))
   id="${REGISTERED_BY_NAME[$name]:-}"
 
   if [[ -n "$id" ]]; then
-    # Existing job: patch in place (preserves state). Ensure enabled state.
-    enable_flag="--enable"
+    # Existing job: patch in place (preserves state). Reflect the manifest's
+    # enabled flag rather than forcing --enable.
+    enable_flag=$([[ "$enabled" == "1" ]] && echo "--enable" || echo "--disable")
     op=(openclaw cron edit "$id" "$enable_flag" "${args[@]}")
   else
-    # New job: create.
+    # New job: `add` defaults to enabled; pass --disabled when the manifest
+    # says the job should be off.
     op=(openclaw cron add "${args[@]}")
+    [[ "$enabled" == "0" ]] && op+=(--disabled)
   fi
 
   if [[ $DRY_RUN -eq 1 ]]; then

--- a/scripts/verify-cron-playbooks.sh
+++ b/scripts/verify-cron-playbooks.sh
@@ -46,7 +46,9 @@ BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
 MANIFEST="$BUILD_DIR/manifest.json"
 
-if ! python3 "$WORKSPACE_ROOT/scripts/build-cron-jobs.py" --output "$MANIFEST" >/dev/null 2>"$BUILD_DIR/build.err"; then
+# Build with --allow-unset-env so the build never fails on an unset ${ENV}
+# reference; live/snapshot modes enforce resolution explicitly below.
+if ! python3 "$WORKSPACE_ROOT/scripts/build-cron-jobs.py" --allow-unset-env --output "$MANIFEST" >/dev/null 2>"$BUILD_DIR/build.err"; then
   echo "verify-cron-playbooks: BUILD FAILED" >&2
   cat "$BUILD_DIR/build.err" >&2
   exit 1
@@ -56,6 +58,16 @@ if [[ "$MODE" == "offline" ]]; then
   N="$(python3 -c "import json,sys; print(len(json.load(open('$MANIFEST'))['jobs']))")"
   echo "verify-cron-playbooks: offline OK ($N jobs; manifest builds and is self-consistent)"
   exit 0
+fi
+
+# Comparing against the live registry only makes sense once ${ENV} references
+# (e.g. the alert number) are resolved — otherwise every such field reports
+# spurious drift. Fail with an actionable message instead.
+UNRESOLVED="$(python3 -c "import json; print(','.join(json.load(open('$MANIFEST')).get('unresolved_env') or []))")"
+if [[ -n "$UNRESOLVED" ]]; then
+  echo "verify-cron-playbooks: unresolved env var(s): $UNRESOLVED" >&2
+  echo "  export them before running --live/--snapshot (see docs/cron.md)" >&2
+  exit 1
 fi
 
 # Acquire the comparison set.

--- a/scripts/verify-cron-playbooks.sh
+++ b/scripts/verify-cron-playbooks.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Drift detector for knishioka-pm cron jobs.
+#
+# Builds the canonical cron manifest from config/cron/jobs.yaml and compares
+# it to either:
+#   (a) the live registered cron jobs (`openclaw cron list --json`)
+#   (b) a recorded snapshot JSON (for CI / offline use)
+#
+# Reports any divergence by job name. Exit code:
+#   0  no drift detected (or offline build OK)
+#   1  invalid CLI / build failure
+#   2  drift detected
+#
+# Usage:
+#   scripts/verify-cron-playbooks.sh                  # default: live mode
+#   scripts/verify-cron-playbooks.sh --live           # explicit live mode
+#   scripts/verify-cron-playbooks.sh --offline        # build-only (no openclaw call)
+#   scripts/verify-cron-playbooks.sh --snapshot <path>  # compare to JSON snapshot
+#
+# CI use: --offline ensures config/cron/jobs.yaml parses and the manifest is
+# self-consistent. --live additionally verifies the local registry matches the
+# canonical source. The script never mutates the registry.
+#
+# Adapted from ds-pm (~/.openclaw/workspace-ds-pm/scripts/verify-cron-playbooks.sh).
+# knishioka jobs are singletons with inline messages (no playbook files), so the
+# comparison covers message_hash, schedule, delivery, and payload metadata.
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENT_ID="knishioka-pm"
+MODE=live
+SNAPSHOT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --live) MODE=live; shift ;;
+    --offline) MODE=offline; shift ;;
+    --snapshot) MODE=snapshot; SNAPSHOT_PATH="$2"; shift 2 ;;
+    -h|--help) sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "verify-cron-playbooks: unknown arg '$1'" >&2; exit 1 ;;
+  esac
+done
+
+# Build the canonical manifest into a tmp file (never commits).
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+MANIFEST="$BUILD_DIR/manifest.json"
+
+if ! python3 "$WORKSPACE_ROOT/scripts/build-cron-jobs.py" --output "$MANIFEST" >/dev/null 2>"$BUILD_DIR/build.err"; then
+  echo "verify-cron-playbooks: BUILD FAILED" >&2
+  cat "$BUILD_DIR/build.err" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "offline" ]]; then
+  N="$(python3 -c "import json,sys; print(len(json.load(open('$MANIFEST'))['jobs']))")"
+  echo "verify-cron-playbooks: offline OK ($N jobs; manifest builds and is self-consistent)"
+  exit 0
+fi
+
+# Acquire the comparison set.
+case "$MODE" in
+  live)
+    if ! command -v openclaw >/dev/null 2>&1; then
+      echo "verify-cron-playbooks: 'openclaw' not on PATH (use --offline for static check)" >&2
+      exit 1
+    fi
+    REG="$BUILD_DIR/registered.json"
+    if ! openclaw cron list --json >"$REG" 2>"$BUILD_DIR/openclaw.err"; then
+      echo "verify-cron-playbooks: openclaw cron list FAILED" >&2
+      cat "$BUILD_DIR/openclaw.err" >&2
+      exit 1
+    fi
+    ;;
+  snapshot)
+    if [[ ! -f "$SNAPSHOT_PATH" ]]; then
+      echo "verify-cron-playbooks: snapshot file not found: $SNAPSHOT_PATH" >&2
+      exit 1
+    fi
+    REG="$SNAPSHOT_PATH"
+    ;;
+esac
+
+# Compare manifest jobs to registered knishioka-pm jobs by name.
+MANIFEST="$MANIFEST" REG="$REG" AGENT_ID="$AGENT_ID" python3 <<'PYEOF'
+import json
+import hashlib
+import os
+import sys
+
+manifest = json.load(open(os.environ["MANIFEST"]))
+registered = json.load(open(os.environ["REG"]))
+agent_id = os.environ["AGENT_ID"]
+
+
+def msg_hash(s):
+    return hashlib.sha256((s or "").rstrip().encode("utf-8")).hexdigest()
+
+
+reg_by_name = {
+    j["name"]: j
+    for j in registered.get("jobs", [])
+    if j.get("agentId") == agent_id
+}
+manifest_by_name = {j["name"]: j for j in manifest["jobs"]}
+
+issues = []
+
+# (1) names in manifest but not registered.
+for n in sorted(set(manifest_by_name) - set(reg_by_name)):
+    issues.append(("missing", n, "manifest defines this job but it is not registered"))
+
+# (2) names registered but not in manifest.
+for n in sorted(set(reg_by_name) - set(manifest_by_name)):
+    issues.append(("extra", n, f"registered {agent_id} job not in manifest (manual? candidate for cleanup)"))
+
+for name, mj in manifest_by_name.items():
+    rj = reg_by_name.get(name)
+    if rj is None:
+        continue
+    payload = rj.get("payload") or {}
+    if isinstance(payload, str):
+        payload = {"message": payload}
+
+    # (3) message hash divergence.
+    reg_hash = msg_hash(payload.get("message", ""))
+    if reg_hash != mj["message_hash"]:
+        issues.append((
+            "message-drift",
+            name,
+            f"message_hash differs (built={mj['message_hash'][:12]}.. registered={reg_hash[:12]}..)",
+        ))
+
+    # (4) schedule divergence.
+    msch = mj["schedule"]
+    rsch = rj.get("schedule") or {}
+    if msch.get("kind") != rsch.get("kind"):
+        issues.append(("schedule-kind", name, f"built={msch.get('kind')} registered={rsch.get('kind')}"))
+    elif msch.get("kind") == "cron":
+        if msch.get("expr") != rsch.get("expr"):
+            issues.append(("schedule", name, f"cron expr: built={msch.get('expr')!r} registered={rsch.get('expr')!r}"))
+        if msch.get("tz") and rsch.get("tz") and msch["tz"] != rsch["tz"]:
+            issues.append(("schedule-tz", name, f"tz: built={msch['tz']!r} registered={rsch['tz']!r}"))
+
+    # (5) delivery divergence (mode/channel/to).
+    md = mj.get("delivery") or {}
+    rd = rj.get("delivery") or {}
+    for key, rkey in (("mode", "mode"), ("channel", "channel"), ("to", "to")):
+        mv = md.get(key)
+        rv = rd.get(rkey)
+        if mv is None and rv is None:
+            continue
+        if mv != rv:
+            issues.append(("delivery", name, f"{key}: built={mv!r} registered={rv!r}"))
+
+    # (6) payload metadata divergence (thinking/timeout/model).
+    if mj.get("thinking") is not None and mj["thinking"] != payload.get("thinking"):
+        issues.append(("thinking", name, f"built={mj['thinking']!r} registered={payload.get('thinking')!r}"))
+    if mj.get("timeout_seconds") is not None and mj["timeout_seconds"] != payload.get("timeoutSeconds"):
+        issues.append(("timeout", name, f"built={mj['timeout_seconds']!r} registered={payload.get('timeoutSeconds')!r}"))
+    if mj.get("model") is not None and mj["model"] != payload.get("model"):
+        issues.append(("model", name, f"built={mj['model']!r} registered={payload.get('model')!r}"))
+
+if not issues:
+    print(f"verify-cron-playbooks: no drift ({len(manifest_by_name)} jobs match registered)")
+    sys.exit(0)
+
+by_kind = {}
+for kind, name, msg in issues:
+    by_kind.setdefault(kind, []).append((name, msg))
+
+print(f"verify-cron-playbooks: DRIFT ({len(issues)} issues across {len(by_kind)} categories)")
+for kind in sorted(by_kind):
+    print(f"  [{kind}] ({len(by_kind[kind])})")
+    for name, msg in by_kind[kind]:
+        print(f"    - {name}: {msg}")
+print()
+print("Hint: re-run scripts/register-cron-jobs.sh after rebuild to sync.")
+sys.exit(2)
+PYEOF


### PR DESCRIPTION
## Summary

Resolves #37. knishioka-pm の cron ジョブ定義を、手動管理かつ非git の `~/.openclaw/cron/jobs.json`（`jobs.json.bak.*` が散乱、差分レビュー・履歴・ロールバック不能）から、**リポ配下の宣言的ソース** に移行する。ds-pm ワークスペースの build/register/verify の仕組みを移植・調整した。

**本PRはライブ登録(`~/.openclaw/cron/jobs.json`)を変更しない** — 宣言化 + 検証のみ。実際の再登録は `scripts/register-cron-jobs.sh` で Ken がマージ後に実行する（state を保持したまま in-place 更新）。

## 変更内容

| ファイル | 役割 |
| --- | --- |
| `config/cron/jobs.yaml` | **source-of-truth**。現行5ジョブを写経（live registry から byte-faithful 生成） |
| `scripts/build-cron-jobs.py` | jobs.yaml → `build/cron/manifest.json`（message_hash 付き、gitignore 済み） |
| `scripts/verify-cron-playbooks.sh` | manifest とライブ登録の drift 検出（`--live`/`--offline`/`--snapshot`、読み取り専用） |
| `scripts/register-cron-jobs.sh` | manifest をライブに適用。**`openclaw cron edit <id>` で in-place 更新** |
| `.gitignore` | 生成物 `build/` を無視 |
| `docs/cron.md` / README / AGENTS.md | 編集→生成→検証→commit 手順を記載 |
| `.github/workflows/check.yml` | PyYAML + `verify --offline` で jobs.yaml の妥当性を CI 検証 |

## state を壊さない設計（#37 制約）

ds-pm 版 register は「rm して add し直す」方式で、新しい job id を発番し `nextRun`/`lastRun`/`consecutiveErrors` をリセットしてしまう。本実装はライブジョブを **名前で突き合わせ、`openclaw cron edit <id>` で in-place 更新**するため、id・state・schedule-identity を保持する。新規ジョブのみ `add`、既存ジョブの削除はしない。

## Acceptance Criteria

- [x] cron ジョブ定義が `config/cron/jobs.yaml` で宣言的に管理される
- [x] 定義から jobs.json を生成/同期するスクリプト（`build-cron-jobs.py` + `register-cron-jobs.sh`）
- [x] 同期後に登録状態を検証するスクリプト（`verify-cron-playbooks.sh`）
- [x] ランタイム状態は生成物として gitignore 済み（`build/`、jobs-state.json はリポ外）
- [x] docs に変更手順を記載（docs/cron.md + README + AGENTS.md）
- [x] 既存 state を保持したまま同期できる設計（edit ベース、dry-run で確認済み）

## 検証

```
$ scripts/build-cron-jobs.py        # → build/cron/manifest.json (5 jobs)
$ scripts/verify-cron-playbooks.sh --live
verify-cron-playbooks: no drift (5 jobs match registered)
$ scripts/verify-cron-playbooks.sh --offline
verify-cron-playbooks: offline OK (5 jobs; manifest builds and is self-consistent)
```

5ジョブすべてで `message_hash` / schedule / delivery / payload metadata がライブ登録と一致（no drift）。markdownlint・ruby YAML parse・bash/py 構文・AGENTS.md size すべて green。

## Out of scope

- 既存ジョブの挙動・スケジュール変更（式はそのまま写経）
- ライブ登録の実際の再登録（マージ後に Ken が `register-cron-jobs.sh` で実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)