### PR TITLE
fix(cron): monthly-portfolio-review を第1日曜のみ発火に修正 (#35)

### DIFF
--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -259,9 +259,9 @@ jobs:
     description: Monthly portfolio-level review of all repos
     schedule:
       kind: cron
-      # +0 = Croner AND modifier: fire only when the date is in days 1-7 AND is
-      # Sunday → first Sunday of the month. Plain `0` would be OR (1-7日 OR 毎週
-      # 日曜) and over-fired ~11x/month. See Issue #35.
+      # Use the '+' modifier (Croner extension) to force an AND relationship between
+      # the day-of-month (1-7) and day-of-week (0=Sunday) fields, ensuring the
+      # job only fires on the first Sunday of the month.
       expr: 0 19 1-7 * +0
     timeout_seconds: 600
     delivery:

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -259,7 +259,10 @@ jobs:
     description: Monthly portfolio-level review of all repos
     schedule:
       kind: cron
-      expr: 0 19 1-7 * 0
+      # +0 = Croner AND modifier: fire only when the date is in days 1-7 AND is
+      # Sunday → first Sunday of the month. Plain `0` would be OR (1-7日 OR 毎週
+      # 日曜) and over-fired ~11x/month. See Issue #35.
+      expr: 0 19 1-7 * +0
     timeout_seconds: 600
     delivery:
       mode: announce


### PR DESCRIPTION
## 概要

`monthly-portfolio-review` の cron 式 `0 19 1-7 * 0` は **日(1-7)** と **曜日(0=日曜)** を両方非ワイルドカードで指定しており、Croner(Vixie 系)では両フィールドが AND ではなく **OR** で判定される。結果「毎月1〜7日 **または** 毎週日曜」に発火し、月1回想定が **実測 約11回/月** 動いていた（delivery=`announce` なので Ken は月次レビューを毎週日曜に受信していた）。

意図は **毎月第1日曜 19:00 (Asia/Kuala_Lumpur)**。

Closes #35

## 変更

`config/cron/jobs.yaml`（git 管理の source-of-truth、#38 で導入）の当該1ジョブのみ:

```diff
-      expr: 0 19 1-7 * 0
+      expr: 0 19 1-7 * +0
```

Croner の `+` 修飾子は day-of-week を AND 結合する（公式 README: `"0 12 1 * +MON" only runs when the 1st is also a Monday`）。`+0` で「1-7日 **かつ** 日曜」= 第1日曜のみ発火。

## 検証

`croner@latest`, tz=`Asia/Kuala_Lumpur`, 起点 2026-05-21 で次回発火を計算:

| 式 | 次回発火 |
| --- | --- |
| **新 `0 19 1-7 * +0`** | Jun 7 / Jul 5 / Aug 2 / Sep 6 / Oct 4 — **すべて第1日曜** ✅ |
| 旧 `0 19 1-7 * 0` | May 24, May 31, **Jun 1〜7 連日** … OR バグ再現 ❌ |

- `scripts/build-cron-jobs.py --check` → OK (5 jobs)
- `scripts/verify-cron-playbooks.sh --offline` → offline OK

これにより受入基準 1・2（第1日曜のみ発火 / `nextRunAtMs` が翌「第1日曜」を指す）を満たす。

## レビュー後の運用手順（要 Ken）

本 PR はソース定義の修正のみ。ライブ反映と1サイクル経過観察は env(`KNISHIOKA_ALERT_TO`) と live 変更を伴うため、`docs/cron.md` の手順で手動適用が必要:

```bash
export KNISHIOKA_ALERT_TO='+81...'
scripts/build-cron-jobs.py
scripts/register-cron-jobs.sh --dry-run && scripts/register-cron-jobs.sh
scripts/verify-cron-playbooks.sh --live   # drift ゼロ & nextRun=第1日曜 を確認
```

- [ ] (manual) ライブ登録後 `jobs-state.json` の `nextRunAtMs` が次の第1日曜を指すことを確認
- [ ] (manual) 1サイクル経過後 `runs/` で余分な実行が消えたことを確認し `reports/` に記録

## Scope 外

レポート内容のフォーマット変更・他ジョブのスケジュール変更は含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)