### PR TITLE
chore(cron): グローバル maxConcurrentRuns 追加 + failureAlert 被覆監査 (#36)

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,4 +1,4 @@
-<!-- version: 2026-05-21 (Issue #37) -->
+<!-- version: 2026-05-21 (Issue #37, #36) -->
 
 # Cron Job Management
 
@@ -127,3 +127,40 @@ jobs:
 
 CI（`.github/workflows/check.yml`）は `--offline`（+ PyYAML）で
 `config/cron/jobs.yaml` が常にビルド可能であることを保証する。
+
+## グローバル scheduler 設定（`~/.openclaw/openclaw.json` の `cron`）
+
+`jobs.yaml` は **per-job** 定義のソース。一方、スケジューラ**全体**に効く設定
+（同時実行制限・失敗通知の fallback 等）は OpenClaw ランタイム config
+`~/.openclaw/openclaw.json` の `cron` キーに置く。**このファイルは git 追跡外**
+（リポ外の runtime 状態）なので、変更内容は本ドキュメントと `reports/` の監査
+記録でレビュー可能にする。Issue #36 で以下を整備した。
+
+| キー                     | 値  | 意図                                                                  |
+| ------------------------ | --- | --------------------------------------------------------------------- |
+| `cron.maxConcurrentRuns` | `3` | 同時 LLM 実行を 3 本に制限。週次ジョブ集中時の CPU/メモリ多重起動保険 |
+
+```jsonc
+// ~/.openclaw/openclaw.json
+{
+  "cron": {
+    "maxConcurrentRuns": 3,
+  },
+}
+```
+
+- **グローバル設定**のため全ワークスペース（ds-pm / personal / ds-tm / family /
+  knishioka-pm、合計約 50 ジョブ）に作用する。
+- gateway は config を**起動時に読む**。変更後は `openclaw gateway restart` で反映。
+- 編集前に `~/.openclaw/openclaw.json.bak.<日付>` を取得すること。
+
+### `cron.failureDestination` を設定しない理由
+
+OpenClaw には失敗通知が 2 経路ある: per-job/global の `failureAlert`
+（連続 N 回失敗で 1 本に解決）と `failureDestination`（**毎回のエラー**で発火、
+`delivery.bestEffort: true` のジョブのみ抑止）。グローバル `failureDestination`
+を足すと、`bestEffort` 未設定の `focus-task` / `weekly-knowledge-extract` が
+失敗のたびに通知し、既存 `failureAlert` と**二重通知**になる。knishioka-pm の
+全ジョブは既に per-job `failureAlert` を持つ（`defaults.failure_alert`）ため、
+**`failureDestination` は設定しない**。詳細・監査結果は
+`reports/cron-failsafe-audit-20260521.md` を参照。

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -140,13 +140,10 @@ CI（`.github/workflows/check.yml`）は `--offline`（+ PyYAML）で
 | ------------------------ | --- | --------------------------------------------------------------------- |
 | `cron.maxConcurrentRuns` | `3` | 同時 LLM 実行を 3 本に制限。週次ジョブ集中時の CPU/メモリ多重起動保険 |
 
-```jsonc
-// ~/.openclaw/openclaw.json
-{
-  "cron": {
-    "maxConcurrentRuns": 3,
-  },
-}
+`~/.openclaw/openclaw.json` に追記:
+
+```json
+{ "cron": { "maxConcurrentRuns": 3 } }
 ```
 
 - **グローバル設定**のため全ワークスペース（ds-pm / personal / ds-tm / family /

--- a/reports/cron-failsafe-audit-20260521.md
+++ b/reports/cron-failsafe-audit-20260521.md
@@ -48,7 +48,7 @@ cp -p ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.bak.2026-05-21
 | monthly-portfolio-review | ✅      | after:2 / WA / 6h cd | true                |
 | private-repo-check       | ✅      | after:2 / WA / 6h cd | true                |
 
-- `failureAlert`: 連続 2 回失敗で WhatsApp (`+819050822879`)、cooldown 6h、`mode: announce`。
+- `failureAlert`: 連続 2 回失敗で WhatsApp (`${KNISHIOKA_ALERT_TO}`)、cooldown 6h、`mode: announce`。
 - 被覆率 **5/5 = 100%**（silent failure を全ジョブで検知可能）。
 
 ## 3. `cron.failureDestination` を設定しない判断（根拠付き）
@@ -85,7 +85,7 @@ per-job/`delivery.to` 依存で knishioka-pm では追加効果がないため�
 #    （本番ジョブには触れない）。例（疑似）:
 openclaw cron add --name _fa-smoke-test --schedule '@once' \
   --message 'exit 1 で失敗させる検証用' \
-  --failure-after 1 --failure-channel whatsapp --failure-to '+819050822879'
+  --failure-after 1 --failure-channel whatsapp --failure-to "${KNISHIOKA_ALERT_TO}"
 openclaw cron run _fa-smoke-test          # 即時実行
 # 2. WhatsApp に "Cron job _fa-smoke-test failed: ..." が 1 通届くことを確認
 # 3. 後始末（必須）

--- a/reports/cron-failsafe-audit-20260521.md
+++ b/reports/cron-failsafe-audit-20260521.md
@@ -1,0 +1,120 @@
+# Cron フェイルセーフ整備（同時実行制限・failureAlert 被覆監査） (2026-05-21)
+
+> Issue #36。cron 全体のフェイルセーフ設定（同時実行制限・失敗通知の被覆）を
+> 公式ベストプラクティスに寄せる。timeout 調整・スケジュール変更は対象外。
+
+## 1. グローバル同時実行制限 (`cron.maxConcurrentRuns`)
+
+`~/.openclaw/openclaw.json` に `cron` キー自体が存在せず（実質 `{}`）、同時実行の
+保険がなかった。ライブ登録は **全ワークスペース合算で 50 ジョブ**（ds-pm 29 /
+personal 10 / knishioka-pm 5 / ds-tm 5 / family 1）あり、週次ジョブが
+19:00–20:00 帯に集中するため多重起動時の CPU/メモリ保護がない。
+
+**実施:** `cron.maxConcurrentRuns: 3` を追加（公式スキーマ
+`Cron Max Concurrent Runs` 準拠。同時 LLM 実行を 3 本に制限）。
+
+```bash
+# backup（Constraint 準拠）
+cp -p ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.bak.2026-05-21
+```
+
+```jsonc
+// ~/.openclaw/openclaw.json （追加分のみ。他キーは無変更）
+{
+  "cron": {
+    "maxConcurrentRuns": 3
+  },
+  ...
+}
+```
+
+> **注意:** `maxConcurrentRuns` は **全ワークスペース共通のグローバル設定**で、
+> knishioka-pm 以外のジョブのスケジューリングにも作用する（Ken 承認済み）。
+> **gateway が config を読むのは起動時**のため、ライブ反映には
+> `openclaw gateway restart` が必要。本作業では実行中ジョブ／セッションへの
+> 影響を避けるため再起動はしていない。**次回の自然な gateway 再起動で適用**される。
+
+## 2. failureAlert 被覆監査（knishioka-pm enabled ジョブ）
+
+ライブ登録 (`openclaw cron list --json`) を直接監査。**全 5 ジョブが per-job
+`failureAlert` を保有**（`config/cron/jobs.yaml` の `defaults.failure_alert`
+から継承）。AC#2 の「全ジョブが個別 failureAlert を持つ」OR 分岐を満たす。
+
+| Job (knishioka-pm)       | enabled | failureAlert         | delivery.bestEffort |
+| ------------------------ | ------- | -------------------- | ------------------- |
+| weekly-repo-health       | ✅      | after:2 / WA / 6h cd | true                |
+| focus-task               | ✅      | after:2 / WA / 6h cd | （なし）            |
+| weekly-knowledge-extract | ✅      | after:2 / WA / 6h cd | （なし）            |
+| monthly-portfolio-review | ✅      | after:2 / WA / 6h cd | true                |
+| private-repo-check       | ✅      | after:2 / WA / 6h cd | true                |
+
+- `failureAlert`: 連続 2 回失敗で WhatsApp (`+819050822879`)、cooldown 6h、`mode: announce`。
+- 被覆率 **5/5 = 100%**（silent failure を全ジョブで検知可能）。
+
+## 3. `cron.failureDestination` を設定しない判断（根拠付き）
+
+OpenClaw 2026.5.7 のランタイム実装 (`dist/server-cron-*.js`) を読解した結果、
+失敗通知には **独立した 2 経路** がある:
+
+| 経路                 | 発火条件                                                                                                                         | 宛先解決                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `failureAlert`       | 連続 N 回失敗（cooldown あり）。per-job が global を上書きし **ジョブ毎に 1 本**に解決 (`resolveFailureAlert`)                   | per-job `to` → `delivery.to` |
+| `failureDestination` | **毎回のエラーで発火**。`delivery.bestEffort === true` のジョブのみ抑止 (`dispatchCronFailureDestinationNotifications` のガード) | per-job → global fallback    |
+
+グローバル `failureDestination` を設定すると、`bestEffort` 未設定の
+**focus-task / weekly-knowledge-extract** が**失敗のたびに**通知を発火し、
+既存の per-job `failureAlert`（連続 2 回）と**二重通知 (スパム)** になる。
+これは Issue の Constraint「グローバルと個別の二重通知でスパムにならない配分」
+に反する。
+
+**判断: `failureDestination` は設定しない。** per-job `failureAlert` が全
+knishioka-pm ジョブを既に被覆しており（§2）、AC#2 は OR 分岐で充足済み。
+グローバル `cron.failureAlert`（catch-all ポリシー）も、宛先が
+per-job/`delivery.to` 依存で knishioka-pm では追加効果がないため設定しない。
+
+## 4. 失敗通知経路の検証手順
+
+故意失敗のダミー実行は (a) 実際に WhatsApp を送信し、(b) ライブ registry/state
+を汚す恐れがあるため**ドキュメント手順で代替**（Issue AC が許容）。
+
+経路が正しく構成されていることは、ライブ登録の `failureAlert` が §2 のとおり
+全ジョブに焼き込まれていることで確認済み。実配信を手元で確認したい場合の手順:
+
+```bash
+# 1. 検証専用の使い捨てジョブを作り、必ず失敗するコマンドを after:1 で alert
+#    （本番ジョブには触れない）。例（疑似）:
+openclaw cron add --name _fa-smoke-test --schedule '@once' \
+  --message 'exit 1 で失敗させる検証用' \
+  --failure-after 1 --failure-channel whatsapp --failure-to '+819050822879'
+openclaw cron run _fa-smoke-test          # 即時実行
+# 2. WhatsApp に "Cron job _fa-smoke-test failed: ..." が 1 通届くことを確認
+# 3. 後始末（必須）
+openclaw cron rm _fa-smoke-test
+```
+
+> 既存ジョブの自然失敗時は `consecutiveErrors >= 2` で通知が届く設計のため、
+> 通常運用では追加の検証ジョブは不要。
+
+## 5. スコープ外メモ（org 全体の被覆ギャップ → 別 Issue 候補）
+
+org 全体 50 ジョブ中、**6 ジョブが failureAlert 未設定**だが、いずれも
+**他ワークスペース**で Issue の Non-goals に該当（本 Issue 対象外）:
+
+- `personal`: obsidian-heartbeat-001 / ai-english-watchdog / weekday-morning-todo / weekly-okr-review
+- `ds-tm`: invoice-reminder / monthly-contractor-report
+
+→ 必要なら別 Issue で各ワークスペース個別に対応。
+
+## 6. ロールバック手順
+
+```bash
+cp -p ~/.openclaw/openclaw.json.bak.2026-05-21 ~/.openclaw/openclaw.json
+# gateway 再起動済みなら再度 restart で反映
+```
+
+## 関連
+
+- Issue #37 / PR #38: cron ジョブ定義の git 管理化（`config/cron/jobs.yaml`）。
+  per-job `failureAlert` は同 PR の `defaults.failure_alert` で全ジョブに継承。
+- `reports/cron-delivery-none-20260505.md`: delivery.mode 二重配信の整理（前提知識）。
+- 公式: https://docs.openclaw.ai/automation/cron-jobs （Failure Alerts & Retries / Staggering & Load Management）


### PR DESCRIPTION
## Summary

Issue #36 — cron 全体のフェイルセーフ整備（同時実行制限・失敗通知の被覆）。timeout 調整・スケジュール変更は対象外。

公式ベストプラクティス（Failure Alerts & Retries / Staggering & Load Management）に寄せ、(1) グローバル同時実行制限を追加し、(2) knishioka-pm 全ジョブの failureAlert 被覆を監査・記録した。

## 実施内容

### 1. `cron.maxConcurrentRuns: 3`（ライブ適用）
- `~/.openclaw/openclaw.json` に `cron` キーが無かった（実質 `{}`）ため新設。同時 LLM 実行を 3 本に制限。
- **グローバル設定**で全ワークスペース約 50 ジョブ（ds-pm 29 / personal 10 / knishioka-pm 5 / ds-tm 5 / family 1）に作用。週次ジョブが 19:00–20:00 に集中するため多重起動の CPU/メモリ保護。
- backup: `~/.openclaw/openclaw.json.bak.2026-05-21`（Constraint 準拠）。
- ⚠️ **ライブ反映には `openclaw gateway restart` が必要**。実行中ジョブ／セッションへの影響を避けるため本作業では再起動していない（config は永続化済み、次回起動で適用）。

### 2. failureAlert 被覆監査 — 5/5 = 100%
ライブ registry を直接監査。全 5 enabled ジョブが per-job `failureAlert`（連続2回失敗→WhatsApp、6h cooldown）を保有（`config/cron/jobs.yaml` の `defaults.failure_alert` 継承）。→ **AC#2 の「全ジョブが個別 failureAlert を持つ」OR 分岐を充足**。

### 3. `cron.failureDestination` は設定しない（根拠付き判断）
ランタイム実装 (`server-cron-*.js`) 読解の結果、失敗通知は2経路:
- `failureAlert`: 連続 N 回失敗で**ジョブ毎に1本**に解決（per-job が global を上書き）。
- `failureDestination`: **毎回のエラー**で発火し、`delivery.bestEffort: true` のジョブのみ抑止。

グローバル `failureDestination` を足すと `bestEffort` 未設定の **focus-task / weekly-knowledge-extract** が失敗のたびに発火し、既存 `failureAlert` と**二重通知（スパム）**になる → Constraint「二重通知でスパムにならない」に反する。全ジョブが per-job failureAlert を持つため設定不要。

### 4. ドキュメント・記録
- `docs/cron.md`: 「グローバル scheduler 設定」節を追加（`openclaw.json` は git 外のため変更をレビュー可能化）。
- `reports/cron-failsafe-audit-20260521.md`: 監査表・根拠・検証手順・ロールバック・org 全体の被覆ギャップを記録。

## Acceptance Criteria

- [x] `cron.maxConcurrentRuns`（=3）を設定
- [x] `cron.failureDestination` 設定 **or** 全ジョブが個別 failureAlert を持つことを確認 → 後者（5/5）で充足。`failureDestination` は二重通知回避のため意図的に未設定
- [x] knishioka-pm 配下の全 enabled ジョブの failureAlert 被覆を監査・記録
- [x] 失敗通知経路の確認 → 手順を `reports/` に記録（実配信ダミーは registry/WhatsApp 汚染回避のためドキュメント手順で代替。Issue AC が許容）

## スコープ外メモ（別 Issue 候補）

org 全体 50 ジョブ中 6 ジョブが failureAlert 未設定だが、いずれも他ワークスペース（personal 4 / ds-tm 2）で Non-goals に該当。必要なら別 Issue で対応。

## レビュー観点・手動確認事項

- **[手動]** `openclaw gateway restart` 後に maxConcurrentRuns が反映されるか（本 PR では未再起動）。
- openclaw.json はリポ外のため diff には現れない（変更は docs/report で追跡）。backup から `cp` でロールバック可能。
- 検証: `verify-cron-playbooks.sh --offline`/`--live` ともに **no drift (5 jobs)**、markdownlint 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)