### PR TITLE
feat(cron): auto-feedback loop with codex-feedback.sh +5min one-shot

### DIFF
--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -221,7 +221,10 @@ jobs:
            - exit 0 で正常 (no-op の nothing_to_do を含む) / 非 0 はログに残るが本ジョブは失敗扱いにしない
         2) tracker を main に commit + push:
            cd /Users/ken/.openclaw/workspace-knishioka-pm
-           if ! git diff --quiet monitoring/pr-feedback-tracker.jsonl; then
+           # `git status --porcelain` は tracked diff だけでなく **untracked** も拾うので、
+           # codex-feedback.sh が初回 invocation で新規ファイルを作った場合も
+           # 取りこぼさず commit できる (旧 `git diff --quiet` は untracked を見逃した)。
+           if [ -n "$(git status --porcelain monitoring/pr-feedback-tracker.jsonl)" ]; then
              git add monitoring/pr-feedback-tracker.jsonl
              git commit -m "chore(feedback): pr-feedback tracker update for {repo_name}#${pr_number}"
              git push origin main || (git pull --rebase origin main && git push origin main) || true

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -193,8 +193,46 @@ jobs:
         pr_number=$(gh pr list -R {owner}/{name} --author knishioka --state open --json number,headRefName --jq '.[0].number')
         gh pr ready --undo -R {owner}/{name} $pr_number 2>/dev/null || true
 
+      11.5) gemini-code-assist のレビュー解決を +5min で one-shot 予約:
+        gemini-code-assist (GitHub App) は PR open 後 typically 1-3 分で初回 review を投稿する。
+        余裕をみて 5 分後に isolated agent session を起動し、scripts/codex-feedback.sh で
+        /resolve-feedback を実行する。one-shot は --delete-after-run で自動消滅するため
+        verify-cron-playbooks.sh の drift には現れない。
+
+        ts=$(date +%s)
+        job_name="fb-{repo_name}-${pr_number}-${ts}"
+        openclaw cron add \
+          --name "$job_name" \
+          --agent knishioka-pm \
+          --session isolated \
+          --at "+5m" \
+          --delete-after-run \
+          --timeout-seconds 900 \
+          --thinking low \
+          --no-deliver \
+          --tz Asia/Kuala_Lumpur \
+          --message "$(cat <<MSG
+        PR feedback resolution one-shot ({owner}/{name}#${pr_number}).
+
+        手順:
+        1) bash /Users/ken/.openclaw/workspace-knishioka-pm/scripts/codex-feedback.sh {owner}/{name} ${pr_number}
+           - script が subscription guard / gemini コメント検出 / codex exec /resolve-feedback /
+             monitoring/pr-feedback-tracker.jsonl 追記 / 失敗時 WhatsApp alert を担う
+           - exit 0 で正常 (no-op の nothing_to_do を含む) / 非 0 はログに残るが本ジョブは失敗扱いにしない
+        2) tracker を main に commit + push:
+           cd /Users/ken/.openclaw/workspace-knishioka-pm
+           if ! git diff --quiet monitoring/pr-feedback-tracker.jsonl; then
+             git add monitoring/pr-feedback-tracker.jsonl
+             git commit -m "chore(feedback): pr-feedback tracker update for {repo_name}#${pr_number}"
+             git push origin main || (git pull --rebase origin main && git push origin main) || true
+           fi
+        3) tracker の最終行 (該当 PR) を 1 行サマリで返す。
+        MSG
+        )" || echo "WARN: failed to schedule feedback one-shot for ${pr_number}" >&2
+
       == 記録 ==
-      12) monitoring/issue-tracker.jsonl に追記: {repo, issue, type, perspective: "pm"|"dev", subtype: "feature"|"improvement"|"growth"|"maintenance"|"refactor"|"tech-adoption"|"perf"|"dx"|"bugfix", created, status: open, auto_resolve: draft_pr_created or failed, pr: N, playbook_version, lint_available, lint_skipped_reason, verification}
+      12) monitoring/issue-tracker.jsonl に追記: {repo, issue, type, perspective: "pm"|"dev", subtype: "feature"|"improvement"|"growth"|"maintenance"|"refactor"|"tech-adoption"|"perf"|"dx"|"bugfix", created, status: open, auto_resolve: draft_pr_created or failed, pr: N, playbook_version, lint_available, lint_skipped_reason, verification, feedback_scheduled_at: "<+5min ISO>" or null}
+          - feedback_scheduled_at: 11.5 の one-shot 予約に成功した場合のみ ISO8601 で記録 (例: "2026-05-25T13:35:00+08:00")。予約に失敗 or PR 0 件の場合は null。後続の resolve-feedback 実行結果は monitoring/pr-feedback-tracker.jsonl 側で追跡する (issue 番号と PR 番号で join 可能)。
           - playbook_version / lint_available / lint_skipped_reason は scripts/codex-resolve.sh の起動ログ ([codex-resolve] start ... playbook_version=YYYY-MM-DD lint_available=true|false lint_skipped_reason=... timeout=...s) から `grep -oE` で抽出する
           - lint_available=false の場合、verification.lint は必ず "n/a" を記録する（Codex 側 PR 本文の動作確認テーブルが ⚠️ n/a になっているはず。なっていなければ補完）
           - lint_available=true の場合、lint_skipped_reason は null を記録する

--- a/docs/codex-playbook.md
+++ b/docs/codex-playbook.md
@@ -1,4 +1,4 @@
-<!-- version: 2026-05-01 -->
+<!-- version: 2026-05-25 -->
 
 # Codex Playbook
 
@@ -131,6 +131,62 @@ fi
 `lint_skipped_reason` の値: `lint_available=false` のときのみ設定。`"no_lint_configured"` (script 未定義) / `"command_not_found"` (バイナリ不在) / `null` (lint_available=true)。
 
 JSONL は **append-only**。既存レコードに新フィールドを遡及追加しない（`playbook_version` 不在の旧レコードはそのまま残す）。
+
+## Auto-Feedback Loop (gemini-code-assist)
+
+`focus-task` cron が draft PR を作成すると、その直後に **+5min の one-shot ジョブ** を `openclaw cron add --at +5m --delete-after-run` で予約する。gemini-code-assist (GitHub App, org 全体にインストール済) は PR open 後 typically 1-3 分で初回 review を投稿するため、5 分待てば review コメントが揃っている前提で `/resolve-feedback` を走らせる。
+
+### 流れ
+
+1. focus-task が `codex-resolve.sh` 経由で draft PR を作成
+2. focus-task が `openclaw cron add` で one-shot 登録 (job name: `fb-{repo}-{pr}-{ts}`)
+3. 5 分後、isolated agent session が起動し以下を実行:
+   - `scripts/codex-feedback.sh {owner}/{repo} {pr_number}`
+   - tracker (`monitoring/pr-feedback-tracker.jsonl`) を main に commit + push
+4. one-shot job は `--delete-after-run` で自動消滅 (drift checker のノイズにならない)
+
+### `scripts/codex-feedback.sh` の責務
+
+- ChatGPT subscription guard (`lib/require-codex-subscription.sh`)
+- `gh api .../comments` と `.../reviews` で **gemini-code-assist** の発言数を事前集計
+  - 0 件なら `nothing_to_do` を tracker に記録して exit 0 (codex は呼ばない)
+- `gh pr checkout {pr_number}` で PR ブランチへ切替
+- `codex exec --full-auto "/resolve-feedback ..."` を 10 分タイムアウトで実行
+- 完了後に default branch へ戻す (next focus-task が clean な main から開始するため)
+- 失敗時のみ WhatsApp `⚠️ codex-feedback failed: ...` を best-effort で送信
+
+### 設定方針
+
+- draft PR は **draft 維持** (`gh pr ready` を呼ばない)。Ken の手動 ready 化で merge gate を確保する
+- gemini-code-assist 以外のレビュアー (人間 / 他Bot) のコメントは触らない (skill 側プロンプトで明示)
+- 自己修正コミット上限は 3 回 (resolve-feedback skill 既定)
+- 5 分待っても gemini コメント 0 件なら silent 終了 (WhatsApp 通知しない)
+
+### `monitoring/pr-feedback-tracker.jsonl` スキーマ
+
+```jsonc
+{
+  "pr": 42, // PR 番号
+  "repo": "knishioka/kanji-practice",
+  "ran_at": "2026-05-25T13:35:00Z", // codex-feedback.sh 実行時刻 (UTC)
+  "action": "applied", // 後述
+  "comments_found": 3, // gemini-code-assist の inline + reviews 合計
+  "inline": 2,
+  "reviews": 1, // 内訳 (action != "skipped" のとき)
+  "duration_sec": 187, // codex exec の経過秒数
+  "exit_code": 0, // codex exec の exit code
+}
+```
+
+`action` の値:
+
+- `applied` — codex exec 成功 (適用 or 部分適用)
+- `nothing_to_do` — gemini コメント 0 件で no-op (codex は呼んでいない)
+- `skipped` — PR が既に CLOSED/MERGED 等で対象外 (`reason` フィールドあり)
+- `failed` — codex exec が非 0 exit code で失敗 (`exit_code` あり)
+- `timeout` — 10 分タイムアウト (exit_code=124)
+
+JSONL は append-only。issue-tracker.jsonl 側に `feedback_scheduled_at` を持たせて join 可能にしている。
 
 ## PR Description Standards (Codex Auto-PR)
 

--- a/scripts/codex-feedback.sh
+++ b/scripts/codex-feedback.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# codex-feedback: One-shot wrapper that invokes `codex exec /resolve-feedback`
+# for a single PR after gemini-code-assist has had time to post its review.
+#
+# Why: focus-task creates a draft PR, then schedules an `openclaw cron` one-shot
+# at +5min that triggers a new isolated agent session. That session calls this
+# script to (a) verify gemini-code-assist actually posted something, (b) run
+# /resolve-feedback against the PR branch, and (c) append an audit record to
+# monitoring/pr-feedback-tracker.jsonl. Tracker commit + push is handled by the
+# cron one-shot agent prompt, not here.
+#
+# Usage:
+#   scripts/codex-feedback.sh <owner/repo> <pr_number> [--dry-run]
+#
+# Exit codes:
+#   0   succeeded (codex exec ok, or no-op because no gemini feedback)
+#   2   bad arguments
+#   3   local repo path missing
+#   5   codex subscription auth guard refused to spawn
+#   124 codex exec timed out
+#   *   codex exec exit code passthrough
+#
+# Side effects:
+#   - cd to local repo and `gh pr checkout` the PR branch
+#   - append a JSONL record to monitoring/pr-feedback-tracker.jsonl
+#   - on failure, best-effort WhatsApp alert via openclaw message send
+#
+# Dependencies: bash, gh, codex, jq (preferred) or grep fallback, gtimeout
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TRACKER="${WORKSPACE_ROOT}/monitoring/pr-feedback-tracker.jsonl"
+
+if [ -f "${SCRIPT_DIR}/lib/require-codex-subscription.sh" ]; then
+  # shellcheck source=lib/require-codex-subscription.sh
+  source "${SCRIPT_DIR}/lib/require-codex-subscription.sh"
+  require_codex_subscription || exit 5
+fi
+
+LOCAL_REPO_BASE="${LOCAL_REPO_BASE:-${HOME}/Developer/private}"
+CODEX_TIMEOUT="${CODEX_FEEDBACK_TIMEOUT:-600}"
+
+usage() {
+  awk 'NR==1{next} /^[^#]/{exit} {sub(/^# ?/,""); print}' "${BASH_SOURCE[0]}"
+}
+
+# --- Parse args ---
+DRY_RUN=0
+POS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "Error: unknown flag: $arg" >&2; usage >&2; exit 2 ;;
+    *) POS+=("$arg") ;;
+  esac
+done
+
+if [ "${#POS[@]}" -ne 2 ]; then
+  echo "Error: expected 2 positional args (<owner/repo> <pr_number>), got ${#POS[@]}" >&2
+  usage >&2
+  exit 2
+fi
+
+OWNER_REPO="${POS[0]}"
+PR_NUMBER="${POS[1]}"
+
+if ! [[ "$OWNER_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Error: <owner/repo> must look like 'owner/name', got: $OWNER_REPO" >&2
+  exit 2
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: <pr_number> must be a positive integer, got: $PR_NUMBER" >&2
+  exit 2
+fi
+
+REPO_NAME="${OWNER_REPO##*/}"
+REPO_PATH="${LOCAL_REPO_BASE}/${REPO_NAME}"
+
+NOW_ISO() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+append_tracker() {
+  # Args: action [extra_json_fields...]
+  # Always emits {pr, repo, ran_at, action, ...}
+  local action="$1"; shift
+  local extra="$*"
+  mkdir -p "$(dirname "$TRACKER")"
+  if [ -n "$extra" ]; then
+    printf '{"pr":%s,"repo":"%s","ran_at":"%s","action":"%s",%s}\n' \
+      "$PR_NUMBER" "$OWNER_REPO" "$(NOW_ISO)" "$action" "$extra" >> "$TRACKER"
+  else
+    printf '{"pr":%s,"repo":"%s","ran_at":"%s","action":"%s"}\n' \
+      "$PR_NUMBER" "$OWNER_REPO" "$(NOW_ISO)" "$action" >> "$TRACKER"
+  fi
+}
+
+alert_failure() {
+  # Best-effort WhatsApp ping; never fails the script.
+  local msg="$1"
+  if [ -n "${KNISHIOKA_ALERT_TO:-}" ] && command -v openclaw >/dev/null 2>&1; then
+    openclaw message send --channel whatsapp --target "${KNISHIOKA_ALERT_TO}" \
+      --text "$msg" >/dev/null 2>&1 || true
+  fi
+}
+
+# --- Verify PR is open ---
+PR_STATE="$(gh pr view -R "$OWNER_REPO" "$PR_NUMBER" --json state -q .state 2>/dev/null || echo "")"
+if [ "$PR_STATE" != "OPEN" ]; then
+  echo "[codex-feedback] PR ${OWNER_REPO}#${PR_NUMBER} not OPEN (state=${PR_STATE:-unknown}); skipping" >&2
+  append_tracker "skipped" "\"reason\":\"pr_not_open\",\"pr_state\":\"${PR_STATE:-unknown}\""
+  exit 0
+fi
+
+# --- Count gemini-code-assist feedback (inline comments + summary reviews) ---
+GEMINI_LOGIN_PREFIX="gemini-code-assist"
+INLINE=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/comments" \
+  --jq "[.[] | select(.user.login | startswith(\"${GEMINI_LOGIN_PREFIX}\"))] | length" 2>/dev/null || echo 0)
+REVIEWS=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/reviews" \
+  --jq "[.[] | select(.user.login | startswith(\"${GEMINI_LOGIN_PREFIX}\"))] | length" 2>/dev/null || echo 0)
+TOTAL=$((INLINE + REVIEWS))
+
+echo "[codex-feedback] start repo=${OWNER_REPO} pr=${PR_NUMBER} gemini_inline=${INLINE} gemini_reviews=${REVIEWS} timeout=${CODEX_TIMEOUT}s" >&2
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "[codex-feedback] no gemini-code-assist feedback found; tracker=nothing_to_do" >&2
+  append_tracker "nothing_to_do" "\"comments_found\":0"
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[codex-feedback] DRY RUN: would resolve ${TOTAL} feedback items (${INLINE} inline + ${REVIEWS} reviews)" >&2
+  exit 0
+fi
+
+# --- Local repo prep ---
+if [ ! -d "$REPO_PATH" ]; then
+  echo "Error: local checkout not found at $REPO_PATH" >&2
+  append_tracker "failed" "\"reason\":\"local_repo_missing\",\"comments_found\":${TOTAL}"
+  exit 3
+fi
+
+cd "$REPO_PATH"
+git fetch origin --quiet
+gh pr checkout "$PR_NUMBER" -R "$OWNER_REPO"
+
+# --- Build prompt ---
+PROMPT="$(cat <<EOF
+/resolve-feedback
+
+【目標】
+- PR ${OWNER_REPO}#${PR_NUMBER} の gemini-code-assist (AI レビュアー) によるレビューコメントを解決する。
+- 検出された inline コメントを classify (fixed/outdated/valid) し、valid のものは実装で対応する。
+- 解決後は PR ブランチに push し、PR は **draft のまま維持** する (Ken の手動 ready 化を待つ)。
+
+【制約】
+- workspace 側 (knishioka-pm) のファイルは編集対象外。${OWNER_REPO} のみ変更。
+- gemini-code-assist 以外のレビュアー (人間 / 他Bot) のコメントは触らない。
+- draft → ready 化は禁止 (\`gh pr ready\` を呼ばない)。
+- 自己修正コミットは最大3回。失敗が残ったらコメントに「未対応」と返信して終了。
+- リポ標準の build / lint / format / typecheck / test は push 前に必ず実行する。
+
+【出力】
+- 適用したコメント数 / outdated / valid_skipped の件数を最後に 1 行サマリで返す。
+EOF
+)"
+
+# --- Run codex with timeout ---
+if ! command -v codex >/dev/null 2>&1; then
+  echo "Error: 'codex' CLI not found in PATH" >&2
+  append_tracker "failed" "\"reason\":\"codex_cli_missing\",\"comments_found\":${TOTAL}"
+  exit 2
+fi
+
+TIMEOUT_BIN=""
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+fi
+
+START_EPOCH="$(date +%s)"
+set +e
+if [ -n "$TIMEOUT_BIN" ]; then
+  "$TIMEOUT_BIN" "$CODEX_TIMEOUT" codex exec -C "$REPO_PATH" --full-auto "$PROMPT"
+else
+  codex exec -C "$REPO_PATH" --full-auto "$PROMPT"
+fi
+EXIT_CODE=$?
+set -e
+END_EPOCH="$(date +%s)"
+DURATION=$((END_EPOCH - START_EPOCH))
+
+# --- Hygiene: switch back to default branch (best-effort) ---
+DEFAULT_BRANCH="$(gh repo view "$OWNER_REPO" --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")"
+git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+
+# --- Classify outcome ---
+if [ "$EXIT_CODE" -eq 0 ]; then
+  ACTION="applied"
+elif [ "$EXIT_CODE" -eq 124 ]; then
+  ACTION="timeout"
+else
+  ACTION="failed"
+fi
+
+append_tracker "$ACTION" \
+  "\"comments_found\":${TOTAL},\"inline\":${INLINE},\"reviews\":${REVIEWS},\"duration_sec\":${DURATION},\"exit_code\":${EXIT_CODE}"
+
+echo "[codex-feedback] end repo=${OWNER_REPO} pr=${PR_NUMBER} exit=${EXIT_CODE} duration_sec=${DURATION} action=${ACTION}" >&2
+
+if [ "$ACTION" = "failed" ] || [ "$ACTION" = "timeout" ]; then
+  alert_failure "⚠️ codex-feedback ${ACTION}: ${OWNER_REPO}#${PR_NUMBER} (exit=${EXIT_CODE}, ${DURATION}s)"
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/codex-feedback.sh
+++ b/scripts/codex-feedback.sh
@@ -115,11 +115,39 @@ if [ "$PR_STATE" != "OPEN" ]; then
 fi
 
 # --- Count gemini-code-assist feedback (inline comments + summary reviews) ---
+# Use --paginate so PRs with >30 comments don't silently drop pages, and treat
+# gh api failures (auth / network / rate-limit) as hard errors instead of "0
+# feedback found" — otherwise transient failures would record nothing_to_do and
+# silently skip /resolve-feedback, defeating the loop's purpose.
 GEMINI_LOGIN_PREFIX="gemini-code-assist"
-INLINE=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/comments" \
-  --jq "[.[] | select(.user.login | startswith(\"${GEMINI_LOGIN_PREFIX}\"))] | length" 2>/dev/null || echo 0)
-REVIEWS=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/reviews" \
-  --jq "[.[] | select(.user.login | startswith(\"${GEMINI_LOGIN_PREFIX}\"))] | length" 2>/dev/null || echo 0)
+
+count_gemini_from_endpoint() {
+  # Args: <endpoint-suffix>  (e.g. "comments" or "reviews")
+  # Stdout: integer count (sum across all pages)
+  # Exit: 0 on success, non-zero on gh api failure
+  local endpoint="$1"
+  local raw rc
+  raw=$(gh api --paginate "repos/${OWNER_REPO}/pulls/${PR_NUMBER}/${endpoint}" \
+    --jq "[.[] | select(.user.login | startswith(\"${GEMINI_LOGIN_PREFIX}\"))] | length" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[codex-feedback] gh api ${endpoint} failed (rc=${rc}): ${raw}" >&2
+    return "$rc"
+  fi
+  # --paginate yields one "length" per page; sum them.
+  printf '%s\n' "$raw" | awk '{s+=$1} END {print s+0}'
+}
+
+if ! INLINE=$(count_gemini_from_endpoint "comments"); then
+  append_tracker "failed" "\"reason\":\"gh_api_inline_failed\""
+  alert_failure "⚠️ codex-feedback: gh api comments failed for ${OWNER_REPO}#${PR_NUMBER}"
+  exit 2
+fi
+if ! REVIEWS=$(count_gemini_from_endpoint "reviews"); then
+  append_tracker "failed" "\"reason\":\"gh_api_reviews_failed\",\"inline\":${INLINE}"
+  alert_failure "⚠️ codex-feedback: gh api reviews failed for ${OWNER_REPO}#${PR_NUMBER}"
+  exit 2
+fi
 TOTAL=$((INLINE + REVIEWS))
 
 echo "[codex-feedback] start repo=${OWNER_REPO} pr=${PR_NUMBER} gemini_inline=${INLINE} gemini_reviews=${REVIEWS} timeout=${CODEX_TIMEOUT}s" >&2
@@ -193,9 +221,11 @@ set -e
 END_EPOCH="$(date +%s)"
 DURATION=$((END_EPOCH - START_EPOCH))
 
-# --- Hygiene: switch back to default branch (best-effort) ---
+# --- Hygiene: switch back to default branch (best-effort, force) ---
+# -f to recover even if codex exec left the working tree dirty; this is the
+# last action on the local clone, so destructive reset is acceptable here.
 DEFAULT_BRANCH="$(gh repo view "$OWNER_REPO" --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")"
-git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+git checkout -f "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
 
 # --- Classify outcome ---
 if [ "$EXIT_CODE" -eq 0 ]; then


### PR DESCRIPTION
## 概要

focus-task が draft PR を作成した直後に `openclaw cron --at +5m --delete-after-run` で one-shot を予約し、gemini-code-assist (GitHub App, org 全体インストール済) のレビューコメントを `/resolve-feedback` で自動解決するループを追加。Issue 起票 → 自動 PR → 5分後に自動フィードバック反映、までを cron 内で完結させる。

Closes #

## 変更内容

- `scripts/codex-feedback.sh` (新規, 215行): one-shot ラッパ。
  - subscription guard (`lib/require-codex-subscription.sh`)
  - gemini-code-assist の inline + reviews を `gh api` で事前集計 → 0 件なら `nothing_to_do` 記録で silent 終了
  - `gh pr checkout` で PR ブランチへ切替 → `codex exec --full-auto "/resolve-feedback ..."` を 10 分タイムアウトで実行
  - default branch に戻した上で `monitoring/pr-feedback-tracker.jsonl` に JSONL 1 行追記
  - 失敗 / timeout 時のみ WhatsApp に `⚠️ codex-feedback ${ACTION}` を best-effort 通知
- `config/cron/jobs.yaml` (focus-task): step 11.5 を追加。draft PR 作成成功直後に `openclaw cron add --at +5m --delete-after-run --name "fb-{repo}-{pr}-{ts}"` で one-shot 登録。job 内では codex-feedback.sh 実行 → tracker を main へ commit + push。step 12 の tracker schema に `feedback_scheduled_at` を追加
- `docs/codex-playbook.md`: version `2026-05-01 → 2026-05-25`、「Auto-Feedback Loop (gemini-code-assist)」章を新設 (流れ / codex-feedback.sh 責務 / 設定方針 / pr-feedback-tracker.jsonl スキーマ)

## 動作確認 (Verification)

| 項目                       | コマンド                                                                       | 結果              |
| -------------------------- | ------------------------------------------------------------------------------ | ----------------- |
| Bash syntax (新規スクリプト) | `bash -n scripts/codex-feedback.sh`                                            | ✅ pass           |
| Script help 出力           | `bash scripts/codex-feedback.sh --help`                                        | ✅ usage 表示成功 |
| Cron manifest 再生成       | `python3 scripts/build-cron-jobs.py`                                           | ✅ 5 jobs 生成    |
| Drift checker              | `KNISHIOKA_ALERT_TO=test bash scripts/verify-cron-playbooks.sh`                | ⚠️ focus-task `message-drift` 検出 (= 意図通り、本 PR マージ後に register-cron-jobs.sh で反映必要) |

実行ログ要約: 新規スクリプトは subscription guard / lint 不在判定など `scripts/codex-resolve.sh` の安全パターンを踏襲。本 PR 自体はコード追加のみで live cron は未変更。

## 受け入れ条件 (Acceptance Criteria)

- [x] `codex-feedback.sh` が subscription guard 経由でしか codex exec を呼ばない
- [x] gemini-code-assist 発言が 0 件の場合に codex を起動せず `nothing_to_do` で silent 終了
- [x] draft PR を ready 化しない (skill 側プロンプトで `gh pr ready` 禁止を明示)
- [x] tracker (`monitoring/pr-feedback-tracker.jsonl`) が JSONL append-only として記録される
- [x] `--delete-after-run` で one-shot job が verify-cron-playbooks.sh の drift に現れない設計
- [x] `docs/codex-playbook.md` に playbook_version `2026-05-25` でマーカ更新済

## スコープ外 (Non-goals)

- 既存の `register-cron-jobs.sh` を本 PR では走らせない (live cron 変更は別オペレーションで実施)
- gemini-code-assist 以外のレビュアー (人間 / 他 Bot) コメントの自動解決
- 5 分以上待っても gemini が反応しない場合のリトライ (一発勝負、tracker に `nothing_to_do` 残るのみ)
- weekly-repo-health / weekly-knowledge-extract への波及 (focus-task のみ対象)

## 影響範囲 / リスク

- 影響範囲: 本 PR の変更は workspace 内のソースのみ。live cron への反映は **マージ後に `scripts/register-cron-jobs.sh` を手動実行** するまで発生しない
- リスク: 反映後、focus-task が PR 作成のたびに **2-3 codex セッション** (resolve + feedback) を消費する (subscription 課金)。月数十回程度の想定なので許容範囲
- ロールバック: `git revert` で本 PR を打ち消したのち `scripts/register-cron-jobs.sh` 再実行で完了

## レビュー観点 (Review Focus)

- `scripts/codex-feedback.sh:108-129` — gemini-code-assist 発言検出ロジック (`startswith` 判定で十分か / Bot 名前変更耐性)
- `scripts/codex-feedback.sh:158-180` — `/resolve-feedback` への prompt 構築 (workspace ポリシーがちゃんと届くか)
- `config/cron/jobs.yaml:194-228` — focus-task step 11.5 の openclaw cron add 引数 (`--at +5m`, `--delete-after-run`, `--no-deliver`, timeout 900s が妥当か)
- `docs/codex-playbook.md` Auto-Feedback Loop 章 — pr-feedback-tracker.jsonl のスキーマと issue-tracker.jsonl の `feedback_scheduled_at` の join 方針