### PR TITLE
chore(cron): harden error handling, restore failure alerts, add ollama eval jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ monitoring/health-trend.jsonl
 monitoring/last-suggested.json
 monitoring/active-session.json
 monitoring/private-health.json
+monitoring/ollama-summary-eval.jsonl
+monitoring/ollama-summary-eval-report.md
 monitoring/issue-tracker.jsonl
 monitoring/site-qa-history.jsonl
 

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -84,14 +84,26 @@ jobs:
         e) レイアウト: A4に収まるか、余白が適切か
       11) 問題検出時は reports/latest-health.md の Risks/Blockers に追加 + GitHub Issue 自動作成（type: bugfix）
 
-      == Part 3: Issue Retrospective ==
+      == Part 3: Issue Retrospective（best-effort / ジョブ全体を失敗させない）==
+      重要: このパート全体は best-effort。各ステップが失敗・例外しても握りつぶし、
+      レポートに "Issue retrospective skipped: <理由>" と記録するだけにして
+      **run 全体を error にしない**（Part 1 のレポートが正本）。
       12) monitoring/issue-tracker.jsonl を読む（なければスキップ）
-      13) 各 open Issue を gh issue view で状態確認
+      13) 各 open Issue を gh issue view で状態確認。**個々の `gh issue view` が
+        失敗（削除済み Issue・権限エラー等）してもエラーを握りつぶし、その Issue を
+        skip して次へ進む（run を error にしない）**。
       14) close/merge された Issue の Quality Score を判定（A=merged+未編集, B=merged+編集あり, C=closed without merge）
       15) monitoring/issue-tracker.jsonl を更新
       16) レポート末尾に Issue Tracker セクション追加
 
       17) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
+
+      == 完了ルール（最後に必ず守る）==
+      18) Part 1 のレポート生成・コミットが成功していれば、このジョブは成功扱い。
+        lint / `gh issue view` / `git diff` などの検証系コマンドが失敗しても
+        run を error にしない。**最後のアクションは必ずクリーンな1行サマリーの返却**
+        とし、失敗するツール呼び出しでセッションを終えないこと（最後のツール呼び出しが
+        非0終了すると run 全体が error 扱いになるため）。
 
       WhatsApp配信ルール: ステータス変化 or サイトQA問題検出 or Issue Tracker に注目情報があれば配信。
   - name: focus-task
@@ -302,6 +314,14 @@ jobs:
       8) monitoring/repo-state.json を更新
       9) コミットした後、`git push origin main` を実行する。push が non-fast-forward でリジェクトされた場合は `git pull --rebase origin main` してから1回だけ再試行する。それでも失敗するなら push は諦めてログに残す（ジョブは失敗させない）
 
+      == 完了ルール（最後に必ず守る）==
+      10) ナレッジ抽出とコミットが成功していれば、このジョブは成功扱い。
+        `markdownlint-cli2` / `npx ...` lint / `git diff` などの**検証系コマンドを
+        最後に実行して失敗させないこと**。これらは過去に「作業は成功しているのに
+        最後のツール呼び出しが非0終了して run 全体が error 扱い」になった原因。
+        lint をかけたい場合は best-effort（失敗を握りつぶす）にし、いずれにせよ
+        **最後のアクションは下記サマリーのテキスト返却**で終えること。
+
       更新したファイル数と主な発見（特に新機能候補）を簡潔に返す。
   - name: monthly-portfolio-review
     description: Monthly portfolio-level review of all repos
@@ -340,9 +360,13 @@ jobs:
     description: Bi-weekly health check for private repos (gitignored output only)
     schedule:
       kind: cron
-      expr: 0 20 * * 3
+      # 深夜帯に実行（mbpは常時起動のためローカルollamaが確実に使われ、長時間ランも無害）。
+      expr: 0 3 * * 3
     thinking: low
-    timeout_seconds: 300
+    # ローカルollama(mbp/Tailscale)を主・cloudをフォールバックに使いトークンを節約。
+    # ローカル30Bはツールコール・ループが遅いため timeout を広く取る（週1・深夜可なので許容）。
+    timeout_seconds: 1800
+    model: ollama/qwen3-coder:30b
     delivery:
       mode: none
       channel: whatsapp
@@ -360,5 +384,70 @@ jobs:
       4) 結果を monitoring/private-health.json に書き出す（上書き）
         フォーマット: [{repo, status, days_inactive, open_issues, ci_status, ...}, ...]
       5) git add も git commit もしない
+      6) monitoring/private-health.json を書き終えたら、それで完了。以下を厳守する:
+         - サマリーや整形は一切不要。jq / ruby / python / node などのスクリプトを書いて実行してはならない。
+         - 追加のツール呼び出し・再読み込み・再チェックをしない。
+         - 最後に「DONE」とだけ一言返して即座に終了する。
+      （成果物は private-health.json のみ。要約はどこにも配信されないため作る必要がない。）
+  - name: ollama-summary-eval
+    description: Daily local Ollama model comparison for repo-health summaries
+    schedule:
+      kind: cron
+      # private-repo-check(水03:00)の後に走らせる。その他の日は最新private-healthで同一条件比較。
+      expr: 45 3 * * *
+    thinking: low
+    timeout_seconds: 900
+    model: ollama/qwen3-coder:30b
+    delivery:
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      Ollama summary model evaluation.
 
-      Output Format に従ったサマリーを返す（WhatsApp配信用）。ただしリポの詳細な内容やコードの情報は含めず、名前とステータスのみ。
+      重要:
+      - このジョブは private リポ名を含むため、結果は gitignored の monitoring/ollama-summary-eval.jsonl にのみ保存する。
+      - git add / git commit / git push は実行しない。
+      - Ollama native API の検証が目的。OpenAI互換 /v1 は使わない。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/ollama-summary-eval run を実行
+         - qwen3-coder:30b / gemma4:31b-mlx / glm4:9b / qwen3.5:4b-mlx を比較
+         - 各モデルは keep_alive=0 で前後にアンロード
+         - num_ctx=8192 / think=false / temperature=0
+      3) python の exit code を見るだけでよい。成果物
+         (monitoring/ollama-summary-eval.jsonl) が書けていれば成功。
+
+      重要（ローカル30Bの暴走防止 / private-repo-check と同じ縛り）:
+      - step 2 のあと、追加のツール呼び出し・再読み込み・jsonl の再パース・整形を
+        一切しない。jq / ruby / python / node でサマリーを作ってはならない。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
+        （30B は要約させると暴走して run が `⏰ Cron failed` になるため、
+        最小限の返答に絞る。詳細な集計は週次の ollama-summary-review が行う）
+  - name: ollama-summary-review
+    description: Weekly review of local Ollama summary model comparison results
+    schedule:
+      kind: cron
+      # 2026-06-01 08:05 KUL時点では当日分を過ぎているため、初回は2026-06-08に走る。
+      expr: 50 7 * * 1
+    thinking: low
+    timeout_seconds: 300
+    model: ollama/qwen3-coder:30b
+    delivery:
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      Ollama summary model weekly review.
+
+      重要:
+      - private リポ名を含むため、集計結果は gitignored の monitoring/ollama-summary-eval-report.md にのみ保存する。
+      - git add / git commit / git push は実行しない。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/ollama-summary-eval report --days 7 を実行
+      3) 生成された monitoring/ollama-summary-eval-report.md の recommended_for_repo_health_summary とモデル別スコアを短く返す。

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -46,6 +46,13 @@ repos:
     category: mcp
     notes: "AI-first accounting MCP server — successor to simple-bookkeeping"
 
+  - owner: knishioka
+    name: ai-english-daily-podcast
+    language: Python
+    priority: medium
+    category: education
+    notes: "AI-generated daily English podcast"
+
   # --- Moderately Active ---
   - owner: knishioka
     name: english-note-maker
@@ -116,6 +123,48 @@ private_repos:
     priority: low
     category: tool
     notes: "jGrants API subsidy application support"
+
+  - owner: knishioka
+    name: 1000haku
+    language: Python
+    priority: medium
+    category: tool
+    notes: "1000haku (用途は要追記)"
+
+  - owner: knishioka
+    name: kagoshima-community-kl
+    language: TypeScript
+    priority: low
+    category: web
+    notes: "Kagoshima community site (KL)"
+
+  - owner: D-stats
+    name: nobull-ai
+    language: TypeScript
+    priority: medium
+    category: tool
+    notes: "NoBull AI (D-stats org)"
+
+  - owner: D-stats
+    name: ens-homepage
+    language: TypeScript
+    priority: medium
+    category: web
+    notes: "EnsoSpark homepage (D-stats org)"
+
+  - owner: D-stats
+    name: ds-homepage
+    language: HTML
+    priority: medium
+    category: web
+    notes: "D-stats homepage (D-stats org)"
+
+  - owner: D-stats
+    name: team-spark-ai
+    language: TypeScript
+    priority: medium
+    category: tool
+    notes: "Team Spark AI (D-stats org)"
 
   - owner: knishioka
     name: line-advisor

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -138,33 +138,10 @@ private_repos:
     category: web
     notes: "Kagoshima community site (KL)"
 
-  - owner: D-stats
-    name: nobull-ai
-    language: TypeScript
-    priority: medium
-    category: tool
-    notes: "NoBull AI (D-stats org)"
-
-  - owner: D-stats
-    name: ens-homepage
-    language: TypeScript
-    priority: medium
-    category: web
-    notes: "EnsoSpark homepage (D-stats org)"
-
-  - owner: D-stats
-    name: ds-homepage
-    language: HTML
-    priority: medium
-    category: web
-    notes: "D-stats homepage (D-stats org)"
-
-  - owner: D-stats
-    name: team-spark-ai
-    language: TypeScript
-    priority: medium
-    category: tool
-    notes: "Team Spark AI (D-stats org)"
+  # NOTE: D-stats org repos are intentionally NOT monitored here. SOUL.md limits
+  # this agent to Ken's personal projects and explicitly excludes business
+  # projects (D-stats 等). private-repo-check runs repo-health on every
+  # private_repos entry, so listing them would pull D-stats into scope.
 
   - owner: knishioka
     name: line-advisor

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -21,7 +21,7 @@
 
 | パス                               | 役割                                                               | git  |
 | ---------------------------------- | ------------------------------------------------------------------ | ---- |
-| `config/cron/jobs.yaml`            | 宣言的ソース（5 ジョブ）。**編集するのはここだけ**                 | 追跡 |
+| `config/cron/jobs.yaml`            | 宣言的ソース（7 ジョブ）。**編集するのはここだけ**                 | 追跡 |
 | `scripts/build-cron-jobs.py`       | jobs.yaml → `build/cron/manifest.json` を生成（message_hash 付き） | 追跡 |
 | `scripts/verify-cron-playbooks.sh` | manifest とライブ登録内容を比較し drift を検出（読み取り専用）     | 追跡 |
 | `scripts/register-cron-jobs.sh`    | manifest をライブに適用。**既存ジョブは id を保ったまま edit**     | 追跡 |

--- a/knowledge/decisions/cost-management-mcp-decisions.md
+++ b/knowledge/decisions/cost-management-mcp-decisions.md
@@ -3,19 +3,19 @@
 ## 2026-05-04: fix(security): resolve fast-xml-parser audit finding
 
 - **What**: fix(security): resolve fast-xml-parser audit finding
-- **Why**: `@aws-sdk/xml-builder` 経由で解決されていた脆弱な `fast-xml-parser` を npm `overrides` で安全版へ固定し、Security Scan の `npm audit --production` 失敗を解消します。AWS SDK 本体の広範な更新は行わず、Node.js >=18 の互換性を維持する最小差分にしています。 
+- **Why**: `@aws-sdk/xml-builder` 経由で解決されていた脆弱な `fast-xml-parser` を npm `overrides` で安全版へ固定し、Security Scan の `npm audit --production` 失敗を解消します。AWS SDK 本体の広範な更新は行わず、Node.js >=18 の互換性を維持する最小差分にしています。
 - **Source**: PR #150
 
 ## 2025-11-04: Upgrade Zod to v4 and update schema handling
 
 - **What**: Upgrade Zod to v4 and update schema handling
-- **Why**: ## Summary - bump the Zod dependency to v4.1.12 and refresh the lockfile - adjust environment and tool schemas for the Zod v4 API changes - tighten Anthropic usage handling by replacing the loose any cast with typed helpers 
+- **Why**: ## Summary - bump the Zod dependency to v4.1.12 and refresh the lockfile - adjust environment and tool schemas for the Zod v4 API changes - tighten Anthropic usage handling by replacing the loose any cast with typed helpers
 - **Source**: PR #140
 
 ## 2025-11-03: docs: add AGENTS handbook for repository operations
 
 - **What**: docs: add AGENTS handbook for repository operations
-- **Why**: ## Summary - add repository-wide AGENTS guide outlining project overview, setup, operational commands, and governance rules for future agents 
+- **Why**: ## Summary - add repository-wide AGENTS guide outlining project overview, setup, operational commands, and governance rules for future agents
 - **Source**: PR #136
 
 ## 2025-11-01: Add protocol-level MCP handler tests
@@ -27,11 +27,11 @@
 ## 2025-11-01: Centralize provider definitions and tool routing
 
 - **What**: Centralize provider definitions and tool routing
-- **Why**: ## Summary - add a shared SUPPORTED_PROVIDERS constant and reuse it across configuration and provider listing - refactor the MCP server to pull tool metadata and handlers from a dedicated registry - expand provider listing coverage/tests to 
+- **Why**: ## Summary - add a shared SUPPORTED_PROVIDERS constant and reuse it across configuration and provider listing - refactor the MCP server to pull tool metadata and handlers from a dedicated registry - expand provider listing coverage/tests to
 - **Source**: PR #134
 
 ## 2025-11-01: Fix TypeScript any usage in caching and analytics utilities
 
 - **What**: Fix TypeScript any usage in caching and analytics utilities
-- **Why**: ## Summary - add structured cache key typing and key enumeration support to the cache manager - tighten common error, logging, and type definitions to remove `any` usage - update cost analysis tools to rely on typed metadata and provider na 
+- **Why**: ## Summary - add structured cache key typing and key enumeration support to the cache manager - tighten common error, logging, and type definitions to remove `any` usage - update cost analysis tools to rely on typed metadata and provider na
 - **Source**: PR #133

--- a/knowledge/decisions/freee-mcp-decisions.md
+++ b/knowledge/decisions/freee-mcp-decisions.md
@@ -3,35 +3,35 @@
 ## 2026-05-05: test: migrate Jest suite to Vitest
 
 - **What**: test: migrate Jest suite to Vitest
-- **Why**: Jest + ts-jest のテスト実行環境を Vitest 3 に移行し、ESM/TypeScript 向けの設定を簡素化しました。既存テストの振る舞いは維持しつつ、テストスクリプトとカバレッジ生成を Vitest ベースに更新しています。 
+- **Why**: Jest + ts-jest のテスト実行環境を Vitest 3 に移行し、ESM/TypeScript 向けの設定を簡素化しました。既存テストの振る舞いは維持しつつ、テストスクリプトとカバレッジ生成を Vitest ベースに更新しています。
 - **Source**: PR #180
 
 ## 2026-04-29: feat(kpi): add structured dashboard output
 
 - **What**: feat(kpi): add structured dashboard output
-- **Why**: ## Summary - Upgrade @modelcontextprotocol/sdk to ^1.29.0. - Return structuredContent from freee_kpi_dashboard with company_id, period, and profitability / safety / efficiency / liquidity KPI sections while preserving the existing JSON text 
+- **Why**: ## Summary - Upgrade @modelcontextprotocol/sdk to ^1.29.0. - Return structuredContent from freee_kpi_dashboard with company_id, period, and profitability / safety / efficiency / liquidity KPI sections while preserving the existing JSON text
 - **Source**: PR #178
 
 ## 2026-04-16: refactor(schema): migrate tool registration to Zod 4
 
 - **What**: refactor(schema): migrate tool registration to Zod 4
-- **Why**: ## Summary - upgrade `zod` from `^3.25.28` to `^4.3.6` and refresh the lockfile - replace the `any`-based `registerTool` shim with a typed generic wrapper while keeping tool names and input argument names unchanged - update focused regressi 
+- **Why**: ## Summary - upgrade `zod` from `^3.25.28` to `^4.3.6` and refresh the lockfile - replace the `any`-based `registerTool` shim with a typed generic wrapper while keeping tool names and input argument names unchanged - update focused regressi
 - **Source**: PR #176
 
 ## 2026-03-31: fix(security): pin axios to 1.14.0 to avoid compromised 1.14.1
 
 - **What**: fix(security): pin axios to 1.14.0 to avoid compromised 1.14.1
-- **Why**: - **axios 1.14.1** was published as a malicious version containing a remote access trojan (RAT) via the `plain-crypto-js` dependency ([StepSecurity advisory](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop- 
+- **Why**: - **axios 1.14.1** was published as a malicious version containing a remote access trojan (RAT) via the `plain-crypto-js` dependency ([StepSecurity advisory](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-
 - **Source**: PR #173
 
 ## 2026-03-06: feat(analysis): add freee_partner_analysis tool
 
 - **What**: feat(analysis): add freee_partner_analysis tool
-- **Why**: - Add `freee_partner_analysis` MCP tool for partner-level revenue/expense analysis with concentration risk assessment - Aggregates deals by partner using auto-pagination, computes top N rankings with share %, monthly breakdown, and concentr 
+- **Why**: - Add `freee_partner_analysis` MCP tool for partner-level revenue/expense analysis with concentration risk assessment - Aggregates deals by partner using auto-pagination, computes top N rankings with share %, monthly breakdown, and concentr
 - **Source**: PR #172
 
 ## 2026-03-06: feat(tools): add freee_kpi_dashboard tool
 
 - **What**: feat(tools): add freee_kpi_dashboard tool
-- **Why**: ## Summary - Add `freee_kpi_dashboard` MCP tool that aggregates KPI data from PL, BS, and walletables in a single call - Computes profitability (operating/ordinary profit margins), safety (current/equity ratios), efficiency (receivable/paya 
+- **Why**: ## Summary - Add `freee_kpi_dashboard` MCP tool that aggregates KPI data from PL, BS, and walletables in a single call - Computes profitability (operating/ordinary profit margins), safety (current/equity ratios), efficiency (receivable/paya
 - **Source**: PR #171

--- a/knowledge/decisions/household-finance-decisions.md
+++ b/knowledge/decisions/household-finance-decisions.md
@@ -3,7 +3,7 @@
 ## 2026-03-09: feat: add local JSONL data source and anomaly detection to monthly report
 
 - **What**: feat: add local JSONL data source and anomaly detection to monthly report
-- **Why**: - Add `--source local` option to generate monthly reports from local `transactions.jsonl` file (offline, no Notion API needed) - Add category-level anomaly detection: warns when a category's monthly total exceeds 2x the 3-month average - Ad 
+- **Why**: - Add `--source local` option to generate monthly reports from local `transactions.jsonl` file (offline, no Notion API needed) - Add category-level anomaly detection: warns when a category's monthly total exceeds 2x the 3-month average - Ad
 - **Source**: PR #27
 
 ## 2026-03-08: feat: add transactions.jsonl and import_log.jsonl persistence
@@ -15,13 +15,13 @@
 ## 2026-03-08: feature: add unit tests for categorize + import loaders (#20)
 
 - **What**: feature: add unit tests for categorize + import loaders (#20)
-- **Why**: - Add comprehensive unit tests for `categorize.py` rule matching (41 tests) and `import_to_notion.py` loader functions (27 tests) - 36-payee snapshot regression tests against production `rules.yaml` to detect regressions on rule changes - S 
+- **Why**: - Add comprehensive unit tests for `categorize.py` rule matching (41 tests) and `import_to_notion.py` loader functions (27 tests) - 36-payee snapshot regression tests against production `rules.yaml` to detect regressions on rule changes - S
 - **Source**: PR #24
 
 ## 2026-03-08: feature: add categorization rules and unified import pipeline
 
 - **What**: feature: add categorization rules and unified import pipeline
-- **Why**: - **仕分けルール拡充**: `rules.yaml` を6ルール→45+ルールに拡張。CLAUDE.mdの全カテゴリ体系（住居/教育/食費/交通/日用品/医療/保険/行政/エンタメ/衣類 + 除外項目）を網羅 - **Import スクリプト統合**: `import_to_notion.py` を Revolut/Wise/TNG 全ソース対応の統一パイプラインに書き換え。rules.yaml ベースの自動仕分け + Notion MCP 形式 JSON 出力 - ** 
+- **Why**: - **仕分けルール拡充**: `rules.yaml` を6ルール→45+ルールに拡張。CLAUDE.mdの全カテゴリ体系（住居/教育/食費/交通/日用品/医療/保険/行政/エンタメ/衣類 + 除外項目）を網羅 - **Import スクリプト統合**: `import_to_notion.py` を Revolut/Wise/TNG 全ソース対応の統一パイプラインに書き換え。rules.yaml ベースの自動仕分け + Notion MCP 形式 JSON 出力 - **
 - **Source**: PR #19
 
 ## 2026-01-04: feature: add finance import workflow
@@ -33,5 +33,5 @@
 ## 2026-01-04: feat: complete notion import pipeline
 
 - **What**: feat: complete notion import pipeline
-- **Why**: This PR completes the Notion import pipeline by integrating Revolut/Wise parsing alongside TNG and implementing full Notion batch uploads. It adds categorization, FX conversion, and source_id deduplication so imports can run end-to-end from 
+- **Why**: This PR completes the Notion import pipeline by integrating Revolut/Wise parsing alongside TNG and implementing full Notion batch uploads. It adds categorization, FX conversion, and source_id deduplication so imports can run end-to-end from
 - **Source**: PR #17

--- a/knowledge/decisions/jgrants-app-decisions.md
+++ b/knowledge/decisions/jgrants-app-decisions.md
@@ -9,29 +9,29 @@
 ## 2025-11-23: enhance: Implement password reset with Resend (#89)
 
 - **What**: enhance: Implement password reset with Resend (#89)
-- **Why**: OWASP準拠のパスワードリセット機能を実装しました。ユーザーがパスワードを忘れた際に、Resendによるメール送信でセルフリカバリーできる機能を提供し、サポート負荷を削減します。 
+- **Why**: OWASP準拠のパスワードリセット機能を実装しました。ユーザーがパスワードを忘れた際に、Resendによるメール送信でセルフリカバリーできる機能を提供し、サポート負荷を削減します。
 - **Source**: PR #90
 
 ## 2025-11-07: test: Add E2E and integration tests for Claude API
 
 - **What**: test: Add E2E and integration tests for Claude API
-- **Why**: Issue #87 の対応として、Claude API を活用した補助金申請機能（スケジュール生成・書類生成）の E2E テストおよび統合テストを実装しました。 
+- **Why**: Issue #87 の対応として、Claude API を活用した補助金申請機能（スケジュール生成・書類生成）の E2E テストおよび統合テストを実装しました。
 - **Source**: PR #88
 
 ## 2025-11-06: test: add comprehensive test coverage for organization management APIs (#72)
 
 - **What**: test: add comprehensive test coverage for organization management APIs (#72)
-- **Why**: This PR adds comprehensive test coverage for 4 organization management API endpoints that were previously untested: 
+- **Why**: This PR adds comprehensive test coverage for 4 organization management API endpoints that were previously untested:
 - **Source**: PR #86
 
 ## 2025-11-06: enhance: Add audit logging for critical operations (#71)
 
 - **What**: enhance: Add audit logging for critical operations (#71)
-- **Why**: 重要な操作（削除・更新・権限変更）の監査ログを記録し、コンプライアンス対応とセキュリティインシデント調査を可能にする機能を実装しました。 
+- **Why**: 重要な操作（削除・更新・権限変更）の監査ログを記録し、コンプライアンス対応とセキュリティインシデント調査を可能にする機能を実装しました。
 - **Source**: PR #85
 
 ## 2025-11-06: fix: Prevent authenticated users from accessing login/register pages (#80)
 
 - **What**: fix: Prevent authenticated users from accessing login/register pages (#80)
-- **Why**: 認証済みユーザーが `/login` および `/register` ページにアクセスした際、自動的に `/dashboard` にリダイレクトする機能を追加しました。 
+- **Why**: 認証済みユーザーが `/login` および `/register` ページにアクセスした際、自動的に `/dashboard` にリダイレクトする機能を追加しました。
 - **Source**: PR #84

--- a/knowledge/decisions/kanji-practice-decisions.md
+++ b/knowledge/decisions/kanji-practice-decisions.md
@@ -3,35 +3,35 @@
 ## 2026-05-14: feat(print): customize first page header fields
 
 - **What**: feat(print): customize first page header fields
-- **Why**: 1ページ目ヘッダーの名前欄・日付欄について、表示/非表示とラベル文言を設定パネルから変更できるようにしました。既存設定ロード時はデフォルト値を migration で補完し、2ページ目以降のヘッダー表示は従来どおり維持しています。 
+- **Why**: 1ページ目ヘッダーの名前欄・日付欄について、表示/非表示とラベル文言を設定パネルから変更できるようにしました。既存設定ロード時はデフォルト値を migration で補完し、2ページ目以降のヘッダー表示は従来どおり維持しています。
 - **Source**: PR #34
 
 ## 2026-05-02: feat: harness pack (AGENTS.md / verify.sh / PR template) — Phase B PoC
 
 - **What**: feat: harness pack (AGENTS.md / verify.sh / PR template) — Phase B PoC
-- **Why**: knishioka/openclaw-workspace-knishioka-pm#21 (Phase B PoC) の harness pack を kanji-practice に配備する。 workspace 側で整備した SSOT テンプレ (AGENTS.md / PR template / verify.sh) を本リポに写し、 Codex auto-resolve の振る舞い検証用に最初の運用リポにする。 
+- **Why**: knishioka/openclaw-workspace-knishioka-pm#21 (Phase B PoC) の harness pack を kanji-practice に配備する。 workspace 側で整備した SSOT テンプレ (AGENTS.md / PR template / verify.sh) を本リポに写し、 Codex auto-resolve の振る舞い検証用に最初の運用リポにする。
 - **Source**: PR #32
 
 ## 2026-04-25: feat: 例文写経の練習行を全マス書き取り対象に
 
 - **What**: feat: 例文写経の練習行を全マス書き取り対象に
-- **Why**: 例文写経モードの練習行はこれまで「ターゲット漢字のセルだけ書き取り用の白マス、それ以外は薄字の固定文字を表示（読む対象）」という構成だった。 しかし例文には対象漢字以外にも漢字・ひらがな・カタカナが含まれており、これらもついでに書写練習できれば、1問あたりの運筆練習量を大幅に増やせる。 
+- **Why**: 例文写経モードの練習行はこれまで「ターゲット漢字のセルだけ書き取り用の白マス、それ以外は薄字の固定文字を表示（読む対象）」という構成だった。 しかし例文には対象漢字以外にも漢字・ひらがな・カタカナが含まれており、これらもついでに書写練習できれば、1問あたりの運筆練習量を大幅に増やせる。
 - **Source**: PR #30
 
 ## 2026-04-25: feat: 例文写経モードの練習行数を可変化（デフォルト2行・最大3行）
 
 - **What**: feat: 例文写経モードの練習行数を可変化（デフォルト2行・最大3行）
-- **Why**: 例文写経モード（PrintMode='sentence'）は従来「お手本1行 + 練習1行」の固定構成で、同じ例文を 1 回しか書写できなかった。学習理論上、写経による定着には 2〜3 回の反復が効果的（`.claude/rules/education/learning-theory.md`）。本 PR は A4 1 ページに最低 2 問が収まる制約を保ったまま、例文の繰り返し書写を可能にする。 
+- **Why**: 例文写経モード（PrintMode='sentence'）は従来「お手本1行 + 練習1行」の固定構成で、同じ例文を 1 回しか書写できなかった。学習理論上、写経による定着には 2〜3 回の反復が効果的（`.claude/rules/education/learning-theory.md`）。本 PR は A4 1 ページに最低 2 問が収まる制約を保ったまま、例文の繰り返し書写を可能にする。
 - **Source**: PR #29
 
 ## 2026-04-24: fix: Klee Oneフォントをindex.htmlのlinkタグで読み込む（#27の修正）
 
 - **What**: fix: Klee Oneフォントをindex.htmlのlinkタグで読み込む（#27の修正）
-- **Why**: PR #27 で `src/index.css` に `@import url(...)` で Klee One を読み込んだが、CSS 仕様上 `@import` は他のすべてのルールより前に配置されている必要があり、`@import "tailwindcss"` の後ろに書かれていたため**本番で無効化**されていた。 
+- **Why**: PR #27 で `src/index.css` に `@import url(...)` で Klee One を読み込んだが、CSS 仕様上 `@import` は他のすべてのルールより前に配置されている必要があり、`@import "tailwindcss"` の後ろに書かれていたため**本番で無効化**されていた。
 - **Source**: PR #28
 
 ## 2026-04-24: fix: 教科書体フォント(Klee One)をWebフォントとして読み込む
 
 - **What**: fix: 教科書体フォント(Klee One)をWebフォントとして読み込む
-- **Why**: 漢字練習プリントの漢字がゴシック体で表示される問題を修正。`.font-textbook` クラスは Klee One を `local()` のみで指定していたため、フォント未インストール環境（多くの macOS 標準環境含む）では `serif` フォールバックや OS 標準フォントに落ち、教科書体になっていなかった。 
+- **Why**: 漢字練習プリントの漢字がゴシック体で表示される問題を修正。`.font-textbook` クラスは Klee One を `local()` のみで指定していたため、フォント未インストール環境（多くの macOS 標準環境含む）では `serif` フォールバックや OS 標準フォントに落ち、教科書体になっていなかった。
 - **Source**: PR #27

--- a/knowledge/decisions/math-worksheet-decisions.md
+++ b/knowledge/decisions/math-worksheet-decisions.md
@@ -3,35 +3,35 @@
 ## 2026-05-27: feat(word-en): align English word problems with elementary curriculum
 
 - **What**: feat(word-en): align English word problems with elementary curriculum
-- **Why**: - English Word Problems の各学年に、その学年で実際に習う計算（2桁×1桁、分数加減、小数演算、速さ、百分率など）を確実に含めるよう改修 - 学年に対して簡単すぎる/難しすぎるテンプレートを `minGrade`/`maxGrade` で再配分 - 答えが分数・小数・あまりになるケースを `number | string` でレンダラ変更なしに表示 
+- **Why**: - English Word Problems の各学年に、その学年で実際に習う計算（2桁×1桁、分数加減、小数演算、速さ、百分率など）を確実に含めるよう改修 - 学年に対して簡単すぎる/難しすぎるテンプレートを `minGrade`/`maxGrade` で再配分 - 答えが分数・小数・あまりになるケースを `number | string` でレンダラ変更なしに表示
 - **Source**: PR #72
 
 ## 2026-05-23: feat: add partial product rows for advanced hissan
 
 - **What**: feat: add partial product rows for advanced hissan
-- **Why**: ## 概要 - 4年生向け `hissan-mult-advanced` で部分積を2段に分けて練習できるようにしました - 問題面では部分積の記入欄、解答面では桁を揃えた部分積の数値を表示します - 関連説明と回帰テストを追加しました 
+- **Why**: ## 概要 - 4年生向け `hissan-mult-advanced` で部分積を2段に分けて練習できるようにしました - 問題面では部分積の記入欄、解答面では桁を揃えた部分積の数値を表示します - 関連説明と回帰テストを追加しました
 - **Source**: PR #71
 
 ## 2026-05-12: feat(word-en): raise grade 4-6 difficulty for English word problems
 
 - **What**: feat(word-en): raise grade 4-6 difficulty for English word problems
-- **Why**: 4年生以上の English Word Problems (`word-en`) のレベルが、数値計算面でも英文構造面でも低すぎたため、Grade 4-6 全体を引き上げ。 
+- **Why**: 4年生以上の English Word Problems (`word-en`) のレベルが、数値計算面でも英文構造面でも低すぎたため、Grade 4-6 全体を引き上げ。
 - **Source**: PR #69
 
 ## 2026-05-12: feat: add equation line option for word problems
 
 - **What**: feat: add equation line option for word problems
-- **Why**: 文章題で立式の練習ができるように、文章題系パターンだけに「式を書く欄」トグルを追加しました。トグルON時は日本語文章題・英語文章題・Singapore Math の各問題で、答え欄の前に式欄を表示します。 
+- **Why**: 文章題で立式の練習ができるように、文章題系パターンだけに「式を書く欄」トグルを追加しました。トグルON時は日本語文章題・英語文章題・Singapore Math の各問題で、答え欄の前に式欄を表示します。
 - **Source**: PR #68
 
 ## 2026-05-10: [codex] Improve answer line spacing
 
 - **What**: [codex] Improve answer line spacing
-- **Why**: - Increase the writable area for Japanese word-problem answer lines. - Move the answer line lower for first-grade symbol/counting problems so it uses the blank space below the prompt. - Apply the same minimum answer-line height treatment to 
+- **Why**: - Increase the writable area for Japanese word-problem answer lines. - Move the answer line lower for first-grade symbol/counting problems so it uses the blank space below the prompt. - Apply the same minimum answer-line height treatment to
 - **Source**: PR #66
 
 ## 2026-05-05: fix(number-tracing): match reference handwriting strokes
 
 - **What**: fix(number-tracing): match reference handwriting strokes
-- **Why**: ## Summary Refines the preschool number tracing digits 7, 8, and 9 to better match the supplied handwriting reference. The new shapes focus on the actual pencil path rather than clean vector-symbol outlines. 
+- **Why**: ## Summary Refines the preschool number tracing digits 7, 8, and 9 to better match the supplied handwriting reference. The new shapes focus on the actual pencil path rather than clean vector-symbol outlines.
 - **Source**: PR #65

--- a/knowledge/decisions/meditation-chrome-extension-decisions.md
+++ b/knowledge/decisions/meditation-chrome-extension-decisions.md
@@ -3,29 +3,29 @@
 ## 2025-06-30: feat: Convert to fully offline Chrome extension with local audio
 
 - **What**: feat: Convert to fully offline Chrome extension with local audio
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit a0ceed1
 
 ## 2025-06-12: Update README to reflect current project status
 
 - **What**: Update README to reflect current project status
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 6cdf29c
 
 ## 2025-06-12: Add comprehensive documentation and TTS implementation
 
 - **What**: Add comprehensive documentation and TTS implementation
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 8dd0c4f
 
 ## 2025-06-12: Implement core meditation extension infrastructure
 
 - **What**: Implement core meditation extension infrastructure
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 595c578
 
 ## 2025-06-12: Initial project setup with documentation
 
 - **What**: Initial project setup with documentation
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 5ebc74b

--- a/knowledge/decisions/remotion-math-education-decisions.md
+++ b/knowledge/decisions/remotion-math-education-decisions.md
@@ -3,11 +3,11 @@
 ## 2025-06-17: Update .gitignore to explicitly exclude all video file formats
 
 - **What**: Update .gitignore to explicitly exclude all video file formats
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit de2472e
 
 ## 2025-06-17: Initial commit: Remotion-based math education video generator
 
 - **What**: Initial commit: Remotion-based math education video generator
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 6c32f01

--- a/knowledge/decisions/td-mcp-server-decisions.md
+++ b/knowledge/decisions/td-mcp-server-decisions.md
@@ -3,35 +3,35 @@
 ## 2025-08-03: Fix test expectations for new tool count
 
 - **What**: Fix test expectations for new tool count
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 208b033
 
 ## 2025-08-03: Improve MCP tool descriptions for better AI comprehension
 
 - **What**: Improve MCP tool descriptions for better AI comprehension
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 14c52b4
 
 ## 2025-08-03: Improve workflow retrieval to handle large IDs
 
 - **What**: Improve workflow retrieval to handle large IDs
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit f8c726f
 
 ## 2025-08-02: Fix test expectations for new tool count
 
 - **What**: Fix test expectations for new tool count
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit 5a2394b
 
 ## 2025-08-02: Temporarily disable mypy in CI to unblock development
 
 - **What**: Temporarily disable mypy in CI to unblock development
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit c8063cb
 
 ## 2025-07-12: Add gitleaks for Treasure Data API key protection
 
 - **What**: Add gitleaks for Treasure Data API key protection
-- **Why**: Not explicitly stated in PR/commit body (see source) 
+- **Why**: Not explicitly stated in PR/commit body (see source)
 - **Source**: commit e3015c7

--- a/scripts/ollama-summary-eval
+++ b/scripts/ollama-summary-eval
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Evaluate local Ollama models for private repo health summaries.
+
+The input and outputs include private repo names, so write only to gitignored
+monitoring files. This script intentionally uses Ollama's native /api/chat
+endpoint so `think:false` and `num_ctx` are honored for Gemma/Qwen models.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_HOST = "http://100.86.194.4:11434"
+DEFAULT_MODELS = [
+    "qwen3-coder:30b",
+    "gemma4:31b-mlx",
+    "glm4:9b",
+    "qwen3.5:4b-mlx",
+]
+OUTPUT_JSONL = Path("monitoring/ollama-summary-eval.jsonl")
+OUTPUT_REPORT = Path("monitoring/ollama-summary-eval-report.md")
+
+
+def now_utc() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def post_json(host: str, path: str, payload: dict[str, Any], timeout: int) -> dict[str, Any]:
+    req = urllib.request.Request(
+        host.rstrip("/") + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def unload_models(host: str, models: list[str], timeout: int = 30) -> None:
+    for model in models:
+        try:
+            post_json(host, "/api/generate", {"model": model, "keep_alive": 0}, timeout)
+        except Exception:
+            pass
+
+
+def load_health(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise SystemExit(f"missing private health file: {path}")
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise SystemExit(f"private health file must be a JSON array: {path}")
+    return data
+
+
+def row_value(row: dict[str, Any], dotted: str, default: Any = None) -> Any:
+    cur: Any = row
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(part, default)
+    return cur
+
+
+def health_tsv(rows: list[dict[str, Any]]) -> str:
+    lines = [
+        "\t".join(
+            [
+                "repo",
+                "status",
+                "dependabot_alerts",
+                "ci_status",
+                "days_inactive",
+                "open_issues",
+                "open_prs",
+            ]
+        )
+    ]
+    for row in rows:
+        lines.append(
+            "\t".join(
+                [
+                    str(row.get("repo", "")),
+                    str(row.get("status", "")),
+                    str(row_value(row, "security.dependabot_alerts", 0)),
+                    str(row_value(row, "ci.last_status", "unknown")),
+                    str(row_value(row, "activity.days_inactive", "")),
+                    str(row_value(row, "issues.open_count", "")),
+                    str(row_value(row, "pull_requests.open_count", "")),
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def expected(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    statuses = {"RED": [], "YELLOW": [], "GREEN": []}
+    for row in rows:
+        status = str(row.get("status", "UNKNOWN"))
+        if status in statuses:
+            statuses[status].append(str(row.get("repo", "")))
+
+    def urgency_key(row: dict[str, Any]) -> tuple[int, int, int, int]:
+        status_rank = {"RED": 3, "YELLOW": 2, "GREEN": 1}.get(str(row.get("status")), 0)
+        alerts = int(row_value(row, "security.dependabot_alerts", 0) or 0)
+        ci_bad = 1 if str(row_value(row, "ci.last_status", "")) in {"failure", "skipped", "none"} else 0
+        inactive = int(row_value(row, "activity.days_inactive", 0) or 0)
+        return (status_rank, alerts, ci_bad, inactive)
+
+    urgent = max(rows, key=urgency_key)["repo"] if rows else ""
+    return {
+        "counts": {k: len(v) for k, v in statuses.items()},
+        "urgent": urgent,
+        "yellow": statuses["YELLOW"],
+        "green": statuses["GREEN"],
+    }
+
+
+def build_prompt(tsv: str) -> str:
+    return f"""あなたは repo health のPM監視エージェントです。以下のTSVだけを根拠に、日本語で短いサマリーを出してください。
+
+必須フォーマット:
+Summary: RED x / YELLOW y / GREEN z
+Urgent: <repo> - <理由>
+Watch: <YELLOW repoをカンマ区切り> - <理由>
+Stable: <GREEN repoの傾向を短く>
+Next: <次の1アクション>
+
+制約:
+- GREENをWatchに入れない
+- 最緊急はREDかつdependabot_alerts/ci_statusを重視
+- 120〜180字程度
+
+TSV:
+{tsv}"""
+
+
+def names_for(repo: str) -> set[str]:
+    base = repo.rsplit("/", 1)[-1]
+    return {repo, base}
+
+
+def contains_repo(text: str, repo: str) -> bool:
+    return any(name in text for name in names_for(repo))
+
+
+def evaluate_text(text: str, exp: dict[str, Any]) -> dict[str, Any]:
+    count_match = re.search(
+        r"RED\s*(\d+)\s*/\s*YELLOW\s*(\d+)\s*/\s*GREEN\s*(\d+)", text, re.I
+    )
+    parsed_counts = None
+    counts_correct = False
+    if count_match:
+        parsed_counts = {
+            "RED": int(count_match.group(1)),
+            "YELLOW": int(count_match.group(2)),
+            "GREEN": int(count_match.group(3)),
+        }
+        counts_correct = parsed_counts == exp["counts"]
+
+    urgent_correct = contains_repo(text, exp["urgent"])
+    watch_match = re.search(r"^Watch:\s*(.+)$", text, re.I | re.M)
+    watch_text = watch_match.group(1) if watch_match else text
+    yellow_missing = [repo for repo in exp["yellow"] if not contains_repo(watch_text, repo)]
+    green_in_watch = [repo for repo in exp["green"] if contains_repo(watch_text, repo)]
+    yellow_correct = not yellow_missing
+    watch_clean = not green_in_watch
+
+    checks = {
+        "counts_correct": counts_correct,
+        "urgent_correct": urgent_correct,
+        "yellow_correct": yellow_correct,
+        "watch_clean": watch_clean,
+    }
+    return {
+        "score": sum(1 for value in checks.values() if value),
+        "max_score": len(checks),
+        "checks": checks,
+        "parsed_counts": parsed_counts,
+        "yellow_missing": yellow_missing,
+        "green_in_watch": green_in_watch,
+        "watch_text": watch_text,
+    }
+
+
+def run_model(
+    host: str,
+    model: str,
+    prompt: str,
+    exp: dict[str, Any],
+    num_ctx: int,
+    timeout: int,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "think": False,
+        "keep_alive": "0",
+        "options": {
+            "temperature": 0,
+            "num_ctx": num_ctx,
+            "num_predict": 240,
+        },
+    }
+    started = time.time()
+    try:
+        body = post_json(host, "/api/chat", payload, timeout)
+        elapsed = time.time() - started
+        message = body.get("message") or {}
+        text = (message.get("content") or "").strip()
+        eval_count = int(body.get("eval_count") or 0)
+        eval_duration = int(body.get("eval_duration") or 0)
+        prompt_eval_count = int(body.get("prompt_eval_count") or 0)
+        prompt_eval_duration = int(body.get("prompt_eval_duration") or 0)
+        result = {
+            "ok": bool(text),
+            "error": None if text else "empty_response",
+            "seconds": round(elapsed, 2),
+            "prompt_tokens": prompt_eval_count,
+            "output_tokens": eval_count,
+            "tok_s": round(eval_count / (eval_duration / 1e9), 2)
+            if eval_duration
+            else None,
+            "prompt_tok_s": round(prompt_eval_count / (prompt_eval_duration / 1e9), 2)
+            if prompt_eval_duration
+            else None,
+            "summary": text,
+        }
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        result = {
+            "ok": False,
+            "error": repr(exc),
+            "seconds": round(time.time() - started, 2),
+            "prompt_tokens": 0,
+            "output_tokens": 0,
+            "tok_s": None,
+            "prompt_tok_s": None,
+            "summary": "",
+        }
+
+    result["evaluation"] = evaluate_text(result["summary"], exp) if result["ok"] else None
+    return result
+
+
+def run_eval(args: argparse.Namespace) -> int:
+    host = args.host
+    models = args.models
+    unload_models(host, models + args.extra_unload_models)
+    rows = load_health(args.health_file)
+    exp = expected(rows)
+    prompt = build_prompt(health_tsv(rows))
+    ts = now_utc().isoformat()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    records = []
+    for model in models:
+        unload_models(host, models + args.extra_unload_models)
+        result = run_model(host, model, prompt, exp, args.num_ctx, args.timeout)
+        record = {
+            "ts": ts,
+            "host": host,
+            "model": model,
+            "num_ctx": args.num_ctx,
+            "health_file": str(args.health_file),
+            "health_checked_at": sorted({row.get("checked_at") for row in rows if row.get("checked_at")}),
+            "expected": exp,
+            **result,
+        }
+        records.append(record)
+        with args.output.open("a") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        score = record["evaluation"]["score"] if record.get("evaluation") else 0
+        print(
+            f"{model}: ok={record['ok']} score={score}/4 "
+            f"seconds={record['seconds']} tok_s={record['tok_s']}"
+        )
+
+    unload_models(host, models + args.extra_unload_models)
+    best = sorted(
+        records,
+        key=lambda r: (
+            (r.get("evaluation") or {}).get("score", 0),
+            -float(r.get("seconds") or 9999),
+        ),
+        reverse=True,
+    )[0]
+    print(f"best={best['model']} score={(best.get('evaluation') or {}).get('score', 0)}/4")
+    return 0
+
+
+def parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    records = []
+    if not path.is_file():
+        return records
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def report(args: argparse.Namespace) -> int:
+    cutoff = now_utc() - dt.timedelta(days=args.days)
+    records = []
+    for record in parse_jsonl(args.input):
+        try:
+            record_ts = dt.datetime.fromisoformat(record["ts"])
+        except Exception:
+            continue
+        if record_ts >= cutoff:
+            records.append(record)
+
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        by_model.setdefault(record["model"], []).append(record)
+
+    rows = []
+    for model, model_records in sorted(by_model.items()):
+        scores = [
+            (r.get("evaluation") or {}).get("score", 0)
+            for r in model_records
+            if r.get("ok")
+        ]
+        latencies = [float(r["seconds"]) for r in model_records if r.get("ok")]
+        failures = sum(1 for r in model_records if not r.get("ok"))
+        rows.append(
+            {
+                "model": model,
+                "runs": len(model_records),
+                "failures": failures,
+                "avg_score": statistics.mean(scores) if scores else 0,
+                "perfect": sum(1 for score in scores if score == 4),
+                "avg_seconds": statistics.mean(latencies) if latencies else 0,
+            }
+        )
+
+    ranked = sorted(rows, key=lambda r: (r["avg_score"], r["perfect"], -r["avg_seconds"]), reverse=True)
+    winner = ranked[0]["model"] if ranked else "n/a"
+    generated = now_utc().isoformat()
+
+    lines = [
+        f"# Ollama Summary Eval Report",
+        "",
+        f"- generated_at_utc: {generated}",
+        f"- window_days: {args.days}",
+        f"- records: {len(records)}",
+        f"- recommended_for_repo_health_summary: {winner}",
+        "",
+        "| model | runs | failures | avg_score | perfect | avg_seconds |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in ranked:
+        lines.append(
+            "| {model} | {runs} | {failures} | {avg_score:.2f}/4 | {perfect} | {avg_seconds:.2f} |".format(
+                **row
+            )
+        )
+
+    latest_good = {}
+    for record in records:
+        if record.get("ok"):
+            latest_good[record["model"]] = record
+    if latest_good:
+        lines += ["", "## Latest Good Summaries", ""]
+        for model in sorted(latest_good):
+            summary = latest_good[model].get("summary", "").strip()
+            lines += [f"### {model}", "", "```text", summary, "```", ""]
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines).rstrip() + "\n")
+    print(f"wrote {args.output}")
+    print(f"recommended={winner}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    run_p = sub.add_parser("run", help="Run one model comparison and append JSONL")
+    run_p.add_argument("--host", default=os.environ.get("OLLAMA_HOST", DEFAULT_HOST))
+    run_p.add_argument("--health-file", type=Path, default=Path("monitoring/private-health.json"))
+    run_p.add_argument("--output", type=Path, default=OUTPUT_JSONL)
+    run_p.add_argument("--models", nargs="+", default=DEFAULT_MODELS)
+    run_p.add_argument(
+        "--extra-unload-models",
+        nargs="+",
+        default=["gemma4:31b", "mistral-nemo:latest", "mistral-small3.2:latest"],
+    )
+    run_p.add_argument("--num-ctx", type=int, default=8192)
+    run_p.add_argument("--timeout", type=int, default=300)
+    run_p.set_defaults(func=run_eval)
+
+    report_p = sub.add_parser("report", help="Write a rolling evaluation report")
+    report_p.add_argument("--input", type=Path, default=OUTPUT_JSONL)
+    report_p.add_argument("--output", type=Path, default=OUTPUT_REPORT)
+    report_p.add_argument("--days", type=int, default=7)
+    report_p.set_defaults(func=report)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ollama-summary-eval
+++ b/scripts/ollama-summary-eval
@@ -34,7 +34,8 @@ OUTPUT_REPORT = Path("monitoring/ollama-summary-eval-report.md")
 
 
 def now_utc() -> dt.datetime:
-    return dt.datetime.now(dt.UTC)
+    # dt.UTC is 3.11+; use dt.timezone.utc for 3.10 compatibility.
+    return dt.datetime.now(dt.timezone.utc)
 
 
 def post_json(host: str, path: str, payload: dict[str, Any], timeout: int) -> dict[str, Any]:
@@ -152,6 +153,9 @@ def names_for(repo: str) -> set[str]:
 
 
 def contains_repo(text: str, repo: str) -> bool:
+    # Empty repo would make `"" in text` always True; guard against false positives.
+    if not repo:
+        return False
     return any(name in text for name in names_for(repo))
 
 

--- a/scripts/register-cron-jobs.sh
+++ b/scripts/register-cron-jobs.sh
@@ -182,6 +182,68 @@ PY
 mapfile -d '' -t TOKENS < <(emit_all_args)
 
 FAILED=()
+
+strip_failure_alert_args() {
+  local out=()
+  local skip_next=0
+  local token
+  for token in "$@"; do
+    if [[ $skip_next -eq 1 ]]; then
+      skip_next=0
+      continue
+    fi
+    case "$token" in
+      --failure-alert)
+        ;;
+      --failure-alert-after|--failure-alert-channel|--failure-alert-to|--failure-alert-cooldown|--failure-alert-mode|--failure-alert-account-id)
+        skip_next=1
+        ;;
+      *)
+        out+=("$token")
+        ;;
+    esac
+  done
+  printf '%s\0' "${out[@]}"
+}
+
+extract_failure_alert_args() {
+  local out=()
+  local take_next=0
+  local token
+  for token in "$@"; do
+    if [[ $take_next -eq 1 ]]; then
+      out+=("$token")
+      take_next=0
+      continue
+    fi
+    case "$token" in
+      --failure-alert)
+        out+=("$token")
+        ;;
+      --failure-alert-after|--failure-alert-channel|--failure-alert-to|--failure-alert-cooldown|--failure-alert-mode|--failure-alert-account-id)
+        out+=("$token")
+        take_next=1
+        ;;
+    esac
+  done
+  printf '%s\0' "${out[@]}"
+}
+
+lookup_live_job_id() {
+  local job_name="$1"
+  openclaw cron list --json | JOB_NAME="$job_name" AGENT_ID="$AGENT_ID" python3 <<'PY'
+import json
+import os
+import sys
+
+data = json.load(sys.stdin)
+for job in data.get("jobs", []):
+    if job.get("agentId") == os.environ["AGENT_ID"] and job.get("name") == os.environ["JOB_NAME"]:
+        print(job["id"])
+        break
+PY
+}
+
 i=0
 while (( i < ${#TOKENS[@]} )); do
   name="${TOKENS[i]}"; ((i += 1))
@@ -189,6 +251,7 @@ while (( i < ${#TOKENS[@]} )); do
   argc="${TOKENS[i]}"; ((i += 1))
   args=("${TOKENS[@]:i:argc}"); ((i += argc))
   id="${REGISTERED_BY_NAME[$name]:-}"
+  alert_args=()
 
   if [[ -n "$id" ]]; then
     # Existing job: patch in place (preserves state). Reflect the manifest's
@@ -198,7 +261,11 @@ while (( i < ${#TOKENS[@]} )); do
   else
     # New job: `add` defaults to enabled; pass --disabled when the manifest
     # says the job should be off.
-    op=(openclaw cron add "${args[@]}")
+    # `openclaw cron add` currently does not accept --failure-alert* flags
+    # (edit does). Create first, then patch alerts once the job has an id.
+    mapfile -d '' -t add_args < <(strip_failure_alert_args "${args[@]}")
+    mapfile -d '' -t alert_args < <(extract_failure_alert_args "${args[@]}")
+    op=(openclaw cron add "${add_args[@]}")
     [[ "$enabled" == "0" ]] && op+=(--disabled)
   fi
 
@@ -208,6 +275,15 @@ while (( i < ${#TOKENS[@]} )); do
     if ! "${op[@]}" >/dev/null; then
       FAILED+=("$name")
     else
+      if [[ -z "$id" && ${#alert_args[@]} -gt 0 ]]; then
+        new_id="$(lookup_live_job_id "$name")"
+        if [[ -n "$new_id" ]]; then
+          if ! openclaw cron edit "$new_id" "${alert_args[@]}" >/dev/null; then
+            FAILED+=("$name")
+            continue
+          fi
+        fi
+      fi
       echo "register-cron-jobs: $([[ -n "$id" ]] && echo edited || echo added) $name"
     fi
   fi

--- a/scripts/register-cron-jobs.sh
+++ b/scripts/register-cron-jobs.sh
@@ -28,10 +28,22 @@ DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --manifest) MANIFEST="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    -h|--help) sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'; exit 0 ;;
-    *) echo "register-cron-jobs: unknown arg '$1'" >&2; exit 1 ;;
+    --manifest)
+      MANIFEST="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h | --help)
+      sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "register-cron-jobs: unknown arg '$1'" >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -41,7 +53,7 @@ if [[ ! -f "$MANIFEST" ]]; then
   exit 1
 fi
 
-if ! command -v openclaw >/dev/null 2>&1; then
+if ! command -v openclaw > /dev/null 2>&1; then
   echo "register-cron-jobs: 'openclaw' CLI not on PATH" >&2
   exit 1
 fi
@@ -103,7 +115,7 @@ echo
 # NUL. The leading subcommand (add) or id (edit) and the enable/disable flag are
 # added by the bash caller, which is the side that knows whether the job exists.
 emit_all_args() {
-  MANIFEST="$MANIFEST" python3 <<'PY'
+  MANIFEST="$MANIFEST" python3 << 'PY'
 import json, os, sys
 
 manifest = json.load(open(os.environ["MANIFEST"]))
@@ -195,7 +207,7 @@ strip_failure_alert_args() {
     case "$token" in
       --failure-alert)
         ;;
-      --failure-alert-after|--failure-alert-channel|--failure-alert-to|--failure-alert-cooldown|--failure-alert-mode|--failure-alert-account-id)
+      --failure-alert-after | --failure-alert-channel | --failure-alert-to | --failure-alert-cooldown | --failure-alert-mode | --failure-alert-account-id)
         skip_next=1
         ;;
       *)
@@ -203,7 +215,10 @@ strip_failure_alert_args() {
         ;;
     esac
   done
-  printf '%s\0' "${out[@]}"
+  # Guard: with an empty array, `printf '%s\0'` still fires once and emits a lone
+  # NUL, which mapfile -d '' would read back as a single empty element (making
+  # ${#arr[@]} == 1 instead of 0). Only print when there is something to print.
+  [[ ${#out[@]} -gt 0 ]] && printf '%s\0' "${out[@]}"
 }
 
 extract_failure_alert_args() {
@@ -220,18 +235,25 @@ extract_failure_alert_args() {
       --failure-alert)
         out+=("$token")
         ;;
-      --failure-alert-after|--failure-alert-channel|--failure-alert-to|--failure-alert-cooldown|--failure-alert-mode|--failure-alert-account-id)
+      --failure-alert-after | --failure-alert-channel | --failure-alert-to | --failure-alert-cooldown | --failure-alert-mode | --failure-alert-account-id)
         out+=("$token")
         take_next=1
         ;;
     esac
   done
-  printf '%s\0' "${out[@]}"
+  # Guard: with an empty array, `printf '%s\0'` still fires once and emits a lone
+  # NUL, which mapfile -d '' would read back as a single empty element (making
+  # ${#arr[@]} == 1 instead of 0). Only print when there is something to print.
+  [[ ${#out[@]} -gt 0 ]] && printf '%s\0' "${out[@]}"
 }
 
 lookup_live_job_id() {
   local job_name="$1"
-  openclaw cron list --json | JOB_NAME="$job_name" AGENT_ID="$AGENT_ID" python3 <<'PY'
+  # NOTE: must use `python3 -c`, not a `<<'PY'` heredoc. A heredoc redirects the
+  # program text onto stdin, which clobbers the piped `cron list --json` — then
+  # `json.load(sys.stdin)` sees no data, the lookup returns empty, and newly
+  # added jobs never get their failure alert applied (codex P1).
+  openclaw cron list --json | JOB_NAME="$job_name" AGENT_ID="$AGENT_ID" python3 -c '
 import json
 import os
 import sys
@@ -241,15 +263,19 @@ for job in data.get("jobs", []):
     if job.get("agentId") == os.environ["AGENT_ID"] and job.get("name") == os.environ["JOB_NAME"]:
         print(job["id"])
         break
-PY
+'
 }
 
 i=0
-while (( i < ${#TOKENS[@]} )); do
-  name="${TOKENS[i]}"; ((i += 1))
-  enabled="${TOKENS[i]}"; ((i += 1))
-  argc="${TOKENS[i]}"; ((i += 1))
-  args=("${TOKENS[@]:i:argc}"); ((i += argc))
+while ((i < ${#TOKENS[@]})); do
+  name="${TOKENS[i]}"
+  ((i += 1))
+  enabled="${TOKENS[i]}"
+  ((i += 1))
+  argc="${TOKENS[i]}"
+  ((i += 1))
+  args=("${TOKENS[@]:i:argc}")
+  ((i += argc))
   id="${REGISTERED_BY_NAME[$name]:-}"
   alert_args=()
 
@@ -270,15 +296,17 @@ while (( i < ${#TOKENS[@]} )); do
   fi
 
   if [[ $DRY_RUN -eq 1 ]]; then
-    printf '+'; printf ' %q' "${op[@]}"; printf '\n'
+    printf '+'
+    printf ' %q' "${op[@]}"
+    printf '\n'
   else
-    if ! "${op[@]}" >/dev/null; then
+    if ! "${op[@]}" > /dev/null; then
       FAILED+=("$name")
     else
       if [[ -z "$id" && ${#alert_args[@]} -gt 0 ]]; then
         new_id="$(lookup_live_job_id "$name")"
         if [[ -n "$new_id" ]]; then
-          if ! openclaw cron edit "$new_id" "${alert_args[@]}" >/dev/null; then
+          if ! openclaw cron edit "$new_id" "${alert_args[@]}" > /dev/null; then
             FAILED+=("$name")
             continue
           fi


### PR DESCRIPTION
## 背景

cron の稼働状況を点検したところ、ジョブ本体は動いているものの 2 つの実害が見つかったため対処する。

1. **WhatsApp 障害アラートが死んでいた** — `KNISHIOKA_ALERT_TO` 未設定のまま register されライブの宛先が無効な `"test"` になっており、ジョブが失敗しても通知が届かない状態だった。
2. **`error` ステータスの大半が誤検知** — 本処理（コミット）は成功しているのに、最後の検証系ツール呼び出し（`gh issue view` / `markdownlint` / ローカル30Bの暴走）が非0終了して run 全体が error 扱いになっていた。

## 変更内容

### Fixes
- **`scripts/register-cron-jobs.sh`**: `--failure-alert*` フラグの strip/extract 処理を追加し、WhatsApp 障害アラートが正しく登録されるように（実害①の土台）。
- **`jobs.yaml` weekly-repo-health**: Part 3 (Issue Retrospective) を best-effort 化。削除済み Issue への `gh issue view` で run を error にしない。完了ルールを追加。
- **`jobs.yaml` weekly-knowledge-extract**: 末尾の `markdownlint`/`git diff` で成功 run が error に転落しないよう完了ルールを追加。
- **`jobs.yaml` ollama-summary-eval**: ローカル 30B を「DONE/FAILED のみ・追加ツール呼び出し禁止」に制約し暴走を防止（private-repo-check と同パターン）。

### Adds
- `ollama-summary-eval` / `ollama-summary-review` ジョブ（ローカル qwen3-coder:30b / Tailscale でトークン節約）+ `scripts/ollama-summary-eval`。
- `config/repos.yaml` に監視リポを追加。
- ollama eval 出力（private リポ名を含む）を gitignore。
- `docs/cron.md`: 5 → 7 ジョブに更新。

## 適用状況・検証
- `KNISHIOKA_ALERT_TO=+81...` をセットして build → `register-cron-jobs.sh` で **ライブ適用済み**（既存ジョブは id 保持で in-place edit、state 非破壊）。
- `verify-cron-playbooks.sh --live` → **no drift（7 ジョブ一致）**。
- 全ジョブの `failureAlert.to` が有効な番号に更新されたことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)