### PR TITLE
fix(knowledge): stop generator emitting trailing whitespace (CI markdownlint)

### DIFF
--- a/scripts/knowledge-render.js
+++ b/scripts/knowledge-render.js
@@ -225,7 +225,7 @@ function toDecisionsMarkdown({ decisions }) {
     lines.push(`## ${d.date}: ${d.title}`);
     lines.push('');
     lines.push(`- **What**: ${d.title}`);
-    lines.push(`- **Why**: ${d.why || 'Not explicitly stated in PR/commit body (see source)'} `);
+    lines.push(`- **Why**: ${d.why || 'Not explicitly stated in PR/commit body (see source)'}`);
     lines.push(`- **Source**: ${d.source}`);
     lines.push('');
   }
@@ -240,6 +240,14 @@ function cap200Lines(md) {
   const head = lines.slice(0, 40);
   const tail = lines.slice(lines.length - 140);
   return [...head, '', '_...older entries summarized/omitted to keep within 200 lines..._', '', ...tail].join('\n');
+}
+
+// Strip trailing whitespace from every line. Commit/PR bodies (and templates)
+// can introduce stray trailing spaces that trip markdownlint MD009, which fails
+// the required CI check on every PR. Sanitizing the generated output keeps the
+// knowledge files lint-clean at the source instead of via manual cleanup.
+function stripTrailingWs(md) {
+  return md.replace(/[ \t]+$/gm, '');
 }
 
 // --- Build decisions list ---
@@ -294,8 +302,8 @@ const patterns = inferPatterns({ repo, meta, pkg, readme: data.readme_excerpt })
 const kbPath = path.join(reposDir, `${name}-kb.md`);
 const decisionsPath = path.join(decisionsDir, `${name}-decisions.md`);
 
-const kbMd = cap200Lines(toKbMarkdown({ repo, collectedAt, meta, pkg, patterns, decisions }));
-const decMd = cap200Lines(toDecisionsMarkdown({ decisions }));
+const kbMd = stripTrailingWs(cap200Lines(toKbMarkdown({ repo, collectedAt, meta, pkg, patterns, decisions })));
+const decMd = stripTrailingWs(cap200Lines(toDecisionsMarkdown({ decisions })));
 
 const kbPrev = fs.existsSync(kbPath) ? fs.readFileSync(kbPath, 'utf8') : null;
 const decPrev = fs.existsSync(decisionsPath) ? fs.readFileSync(decisionsPath, 'utf8') : null;


### PR DESCRIPTION
## 背景

CI の必須チェック `markdownlint` が PR のたびに MD009（行末スペース）で落ちる問題の**根本原因**を修正する。先の #42 では既存の `knowledge/decisions/*.md` を一掃して対処したが、生成元を直さないと毎週の `weekly-knowledge-extract` cron が同じ債務を再生産してしまう。

## 根本原因

`scripts/knowledge-render.js` が生成する markdown に行末スペースが混入していた:

1. `- **Why**:` 行のテンプレートリテラル末尾に**リテラルの半角スペース**があった（`...(see source)'} \``）。
2. `d.why` などコミット/PR 本文由来の値にも末尾スペースが入り得る。

これらが毎回 MD009 を発生させ、CI を赤にしていた。

## 変更内容

- `- **Why**:` テンプレートの末尾スペースを削除。
- `stripTrailingWs()` を追加し、KB・decisions 両方の出力を**書き込み前に全行サニタイズ**。本文由来の末尾スペースもファイルに到達しないようにし、債務を発生源で断つ。

## 検証

- `node --check` OK。
- 行末スペースを含むフィクスチャでレンダリング → 生成物を `markdownlint-cli2@0.14.0`（CI と同一バージョン = markdownlint v0.35.0）で検査し **Summary: 0 error(s)**。
- diff は3 hunk・実質8行追加のみ（整形ノイズなし）。

## スコープ外（補足）

CI に prettier は無く、本リポに整形 config も無いため、JS 整形には手を入れていない。今回は CI を直す最小変更に限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)