### PR TITLE
feat(cron): strengthen ollama eval + wire local summary & token report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,11 @@ monitoring/health-trend.jsonl
 monitoring/last-suggested.json
 monitoring/active-session.json
 monitoring/private-health.json
+monitoring/private-health-summary.md
 monitoring/ollama-summary-eval.jsonl
 monitoring/ollama-summary-eval-report.md
+monitoring/ollama-summary-eval.fingerprint.json
+monitoring/cron-token-usage.md
 monitoring/issue-tracker.jsonl
 monitoring/site-qa-history.jsonl
 

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -363,9 +363,11 @@ jobs:
       # 深夜帯に実行（mbpは常時起動のためローカルollamaが確実に使われ、長時間ランも無害）。
       expr: 0 3 * * 3
     thinking: low
-    # ローカルollama(mbp/Tailscale)を主・cloudをフォールバックに使いトークンを節約。
-    # ローカル30Bはツールコール・ループが遅いため timeout を広く取る（週1・深夜可なので許容）。
-    timeout_seconds: 1800
+    # 収集は scripts/private-repo-collect が決定論的に全部やる（gh/jq のみ・LLM不要）。
+    # agent は1コマンド叩いて DONE するだけなので、多段ツールループが無く、
+    # 小型ローカルモデルでもフォールバックせず確実に完走する（旧構成は 30B が
+    # 7リポ分のツールループを捌けず gpt-5.x へフォールバックし課金が発生していた）。
+    timeout_seconds: 600
     model: ollama/qwen3-coder:30b
     delivery:
       mode: none
@@ -375,28 +377,34 @@ jobs:
     message: |
       Private repo health check.
 
-      重要: このジョブの出力は一切コミットしない。
+      これは「収集」だけのジョブ。要約・配信は後段の private-health-summary が行う。
 
       手順:
-      1) config/repos.yaml の private_repos: セクションを読む
-      2) status: on-hold のリポは除外
-      3) 各リポに対して scripts/repo-health {owner}/{name} を実行
-      4) 結果を monitoring/private-health.json に書き出す（上書き）
-        フォーマット: [{repo, status, days_inactive, open_issues, ci_status, ...}, ...]
-      5) git add も git commit もしない
-      6) monitoring/private-health.json を書き終えたら、それで完了。以下を厳守する:
-         - サマリーや整形は一切不要。jq / ruby / python / node などのスクリプトを書いて実行してはならない。
-         - 追加のツール呼び出し・再読み込み・再チェックをしない。
-         - 最後に「DONE」とだけ一言返して即座に終了する。
-      （成果物は private-health.json のみ。要約はどこにも配信されないため作る必要がない。）
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/private-repo-collect を実行
+         - config/repos.yaml の private_repos（on-hold 除外）に repo-health を回し、
+           フルJSON(ネスト)を monitoring/private-health.json に書き出す
+         - 出力は gitignored。git add / commit / push はしない
+      3) python の exit code を見るだけでよい。exit 0 なら成功。
+
+      重要:
+      - step 2 のあと、追加のツール呼び出し・再読み込み・整形を一切しない。
+        自分で repo-health をループしたり jq/python で組み直したりしてはならない
+        （それをやると 30B が暴走して cloud にフォールバックする。スクリプトに任せる）。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
   - name: ollama-summary-eval
-    description: Daily local Ollama model comparison for repo-health summaries
+    description: Ollama model comparison for repo-health summaries (hybrid scoring, golden set)
     schedule:
       kind: cron
-      # private-repo-check(水03:00)の後に走らせる。その他の日は最新private-healthで同一条件比較。
-      expr: 45 3 * * *
+      # 毎週水曜 04:00 KUL に発火するが、--skip-if-unchanged により
+      # 「ゴールデンセット / モデル一覧 / judgeモデル / 採点版」の fingerprint が
+      # 前回実走と同じで、かつ前回から --max-stale-days(=14) 未満なら no-op する。
+      # 実質「変更時＋約2週ごと」。temperature=0 で同入力は毎回同結果になる無駄打ちを排除。
+      expr: 0 4 * * 3
     thinking: low
-    timeout_seconds: 900
+    # 実走日はゴールデン7ケース×4モデル×judge3サンプルのクラウド審査を含むため長め。
+    # SKIP日は数秒で終わる。
+    timeout_seconds: 3600
     model: ollama/qwen3-coder:30b
     delivery:
       mode: none
@@ -404,23 +412,26 @@ jobs:
       to: "${KNISHIOKA_ALERT_TO}"
       best_effort: true
     message: |
-      Ollama summary model evaluation.
+      Ollama summary model evaluation (hybrid scoring).
 
-      重要:
-      - このジョブは private リポ名を含むため、結果は gitignored の monitoring/ollama-summary-eval.jsonl にのみ保存する。
+      概要:
+      - 入力は匿名合成のゴールデンセット scripts/eval-cases/cases.json（private リポ名を含まない）。
+        private-health.json への依存は廃止。
+      - 採点はハイブリッド: 決定論チェック(0-6) + クラウドLLM審査(0-4) = 0-10。
+        審査モデルは候補と別のクラウド強モデル(既定 openai/gpt-5.4)を openclaw 経由で呼ぶ。
+      - 結果は gitignored の monitoring/ollama-summary-eval.jsonl にのみ追記。
       - git add / git commit / git push は実行しない。
-      - Ollama native API の検証が目的。OpenAI互換 /v1 は使わない。
 
       手順:
       1) cd /Users/ken/.openclaw/workspace-knishioka-pm
-      2) python3 scripts/ollama-summary-eval run を実行
-         - qwen3-coder:30b / gemma4:31b-mlx / glm4:9b / qwen3.5:4b-mlx を比較
-         - 各モデルは keep_alive=0 で前後にアンロード
-         - num_ctx=8192 / think=false / temperature=0
-      3) python の exit code を見るだけでよい。成果物
-         (monitoring/ollama-summary-eval.jsonl) が書けていれば成功。
+      2) python3 scripts/ollama-summary-eval run --skip-if-unchanged を実行
+         - 候補: qwen3-coder:30b / gemma4:31b-mlx / glm4:9b / qwen3.5:4b-mlx
+         - 各モデルは keep_alive=0 で前後にアンロード / num_ctx=8192 / think=false / temperature=0
+         - fingerprint 一致かつ前回実走<14日なら "SKIP: ..." を出して即終了する（正常）
+      3) python の exit code を見るだけでよい。exit 0 なら成功
+         （SKIP も実走完了も exit 0）。
 
-      重要（ローカル30Bの暴走防止 / private-repo-check と同じ縛り）:
+      重要（ローカル30Bの暴走防止）:
       - step 2 のあと、追加のツール呼び出し・再読み込み・jsonl の再パース・整形を
         一切しない。jq / ruby / python / node でサマリーを作ってはならない。
       - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
@@ -444,10 +455,81 @@ jobs:
       Ollama summary model weekly review.
 
       重要:
-      - private リポ名を含むため、集計結果は gitignored の monitoring/ollama-summary-eval-report.md にのみ保存する。
+      - 集計結果は gitignored の monitoring/ollama-summary-eval-report.md にのみ保存する。
       - git add / git commit / git push は実行しない。
 
       手順:
       1) cd /Users/ken/.openclaw/workspace-knishioka-pm
-      2) python3 scripts/ollama-summary-eval report --days 7 を実行
-      3) 生成された monitoring/ollama-summary-eval-report.md の recommended_for_repo_health_summary とモデル別スコアを短く返す。
+      2) python3 scripts/ollama-summary-eval report --days 21 を実行
+         （eval は実質隔週実行のため、7日窓だと実走が無い週は空になる。21日窓にする）
+      3) 生成された monitoring/ollama-summary-eval-report.md の
+         recommended_for_repo_health_summary とモデル別 avg_total/avg_det/avg_llm、
+         および「Hardest cases」を短く返す。
+  - name: private-health-summary
+    description: Weekly local-model summary of private repo health, delivered to WhatsApp
+    schedule:
+      kind: cron
+      # private-repo-check(水03:00) と ollama-summary-eval(水04:00) の後に走る。
+      # private-health.json は週1更新なので、要約も週1で十分（同データの再要約を避ける）。
+      expr: 0 5 * * 3
+    thinking: low
+    timeout_seconds: 600
+    model: ollama/qwen3-coder:30b
+    delivery:
+      # 配信はスクリプトが openclaw message send で直接行うため、cron 側は none（二重送信回避）。
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      Private repo health summary (推奨ローカルモデル → WhatsApp).
+
+      これは ollama-summary-eval ベンチが選んだ推奨ローカルモデルを実際に使う「出口」ジョブ。
+      private リポ名はローカル ollama と自分の WhatsApp にのみ送る（cloud には一切出さない）。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/private-health-summarize --to "${KNISHIOKA_ALERT_TO}" を実行
+         - monitoring/private-health.json を読み、推奨モデル（無ければ gemma4:31b-mlx）で
+           RED/YELLOW 要約を生成 → WhatsApp 配信 → monitoring/private-health-summary.md 保存
+         - 推奨モデルは monitoring/ollama-summary-eval-report.md から自動で読む
+         - git add / commit / push はしない
+      3) python の exit code を見るだけでよい。exit 0 なら成功。
+
+      重要（ローカル30Bの暴走防止）:
+      - step 2 のあと、追加のツール呼び出し・再読み込み・整形を一切しない。
+        jq / ruby / python / node で要約を作り直してはならない（配信はスクリプトが済ませている）。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
+  - name: monitoring-token-report
+    description: Weekly token-usage summary of the monitoring cron jobs (cloud vs local), to WhatsApp
+    schedule:
+      kind: cron
+      # 毎週月曜 08:00 KUL。前週の監視ジョブが出したトークン量を集計して配信。
+      expr: 0 8 * * 1
+    thinking: low
+    timeout_seconds: 300
+    model: ollama/qwen3-coder:30b
+    delivery:
+      # 配信はスクリプトが openclaw message send で直接行うため none（二重送信回避）。
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      Monitoring cron token-usage report.
+
+      監視cron(knishioka-pm)が直近で使ったトークンを、cloud(課金) と local(無料/節約) に
+      分けて集計し、WhatsApp に配信する。どのジョブがcloudに落ちている/課金しているかを可視化する。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/cron-token-usage --days 7 --deliver --to "${KNISHIOKA_ALERT_TO}" を実行
+         - openclaw cron runs から各ジョブの usage を集計
+         - run単位で provider を見て cloud/local に振り分け（移行/フォールバックも正しく分割）
+         - monitoring/cron-token-usage.md に保存 + WhatsApp 配信
+         - git add / commit / push はしない
+      3) python の exit code を見るだけでよい。exit 0 なら成功。
+
+      重要（ローカル30Bの暴走防止）:
+      - step 2 のあと、追加のツール呼び出し・整形を一切しない。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。

--- a/scripts/cron-token-usage
+++ b/scripts/cron-token-usage
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Summarize token usage of the monitoring cron jobs.
+
+Pulls per-run usage from `openclaw cron runs --id <id>` for the knishioka-pm
+agent's jobs and aggregates tokens over a window, split by:
+  - CLOUD providers (openai / anthropic / ...) — the tokens that actually cost money
+  - LOCAL providers (ollama) — free compute; also the tokens you DIDN'T spend on
+    cloud by offloading monitoring to a local model
+
+So the report doubles as a scoreboard for the local-LLM offload strategy: a big
+local number next to a small cloud number means the offload is paying off.
+
+Data source fields (per finished run): model, provider, usage{input_tokens,
+output_tokens, total_tokens}, durationMs, status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+AGENT = "knishioka-pm"
+LOCAL_PROVIDERS = {"ollama"}
+OUTPUT = Path("monitoring/cron-token-usage.md")
+
+
+def now_ms() -> int:
+    return int(dt.datetime.now(dt.timezone.utc).timestamp() * 1000)
+
+
+def run_openclaw(args: list[str], timeout: int = 60) -> Any:
+    proc = subprocess.run(["openclaw", *args], capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError(f"openclaw {' '.join(args)} exit {proc.returncode}: {proc.stderr.strip()[:200]}")
+    start = proc.stdout.find("{")
+    if start < 0:
+        raise RuntimeError(f"openclaw {' '.join(args)}: no JSON in output")
+    return json.loads(proc.stdout[start:])
+
+
+def list_jobs(agent: str) -> list[dict[str, Any]]:
+    data = run_openclaw(["cron", "list", "--json"])
+    jobs = data.get("jobs", data) if isinstance(data, dict) else data
+    if not agent:
+        return list(jobs)
+    return [j for j in jobs if j.get("agentId") == agent]
+
+
+def job_runs(job_id: str, limit: int) -> list[dict[str, Any]]:
+    try:
+        data = run_openclaw(["cron", "runs", "--id", job_id, "--limit", str(limit)])
+    except Exception as exc:
+        print(f"warn: runs for {job_id}: {exc}", file=sys.stderr)
+        return []
+    return data.get("entries", []) if isinstance(data, dict) else []
+
+
+def deliver_whatsapp(to: str, text: str, timeout: int = 60) -> bool:
+    try:
+        proc = subprocess.run(
+            ["openclaw", "message", "send", "--channel", "whatsapp", "--target", to, "--message", text],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception as exc:
+        print(f"deliver: {exc!r}", file=sys.stderr)
+        return False
+    return proc.returncode == 0
+
+
+def fmt(n: int) -> str:
+    return f"{n:,}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--agent", default=AGENT)
+    p.add_argument("--days", type=int, default=14)
+    p.add_argument("--limit", type=int, default=100, help="Max runs to scan per job")
+    p.add_argument("--names", nargs="*", default=None, help="Restrict to these job names (default: agent's monitoring jobs)")
+    p.add_argument("--output", type=Path, default=OUTPUT)
+    p.add_argument("--to", default=None)
+    p.add_argument("--deliver", action="store_true")
+    args = p.parse_args(argv)
+
+    cutoff = now_ms() - args.days * 86400 * 1000
+    jobs = list_jobs(args.agent)
+    if args.names:
+        jobs = [j for j in jobs if j.get("name") in set(args.names)]
+
+    per_job = []
+    for j in jobs:
+        jid, name = j.get("id"), j.get("name")
+        if not jid:
+            continue
+        # Tokens are bucketed per-run by that run's OWN provider, so a job that
+        # migrated mid-window (cloud → local) is split correctly instead of
+        # being collapsed to a single provider.
+        agg = {
+            "name": name, "runs": 0, "ok": 0, "err": 0, "dur_ms": 0,
+            "cloud_tok": 0, "local_tok": 0, "models": set(),
+        }
+        seen_runs = set()
+        for e in job_runs(jid, args.limit):
+            if e.get("action") != "finished":
+                continue
+            ts = e.get("runAtMs") or e.get("ts") or 0
+            if ts < cutoff:
+                continue
+            key = e.get("runId") or ts
+            if key in seen_runs:
+                continue
+            seen_runs.add(key)
+            agg["runs"] += 1
+            agg["ok" if e.get("status") == "ok" else "err"] += 1
+            provider = e.get("provider") or "?"
+            model = e.get("model") or "?"
+            agg["models"].add(f"{provider}:{model}")
+            total = int((e.get("usage") or {}).get("total_tokens") or 0)
+            if provider in LOCAL_PROVIDERS:
+                agg["local_tok"] += total
+            else:
+                agg["cloud_tok"] += total
+            agg["dur_ms"] += int(e.get("durationMs") or 0)
+        if agg["runs"]:
+            agg["total"] = agg["cloud_tok"] + agg["local_tok"]
+            per_job.append(agg)
+
+    per_job.sort(key=lambda a: a["cloud_tok"], reverse=True)
+    cloud_total = sum(a["cloud_tok"] for a in per_job)
+    local_total = sum(a["local_tok"] for a in per_job)
+    runs_total = sum(a["runs"] for a in per_job)
+
+    lines = [
+        f"# Monitoring cron token usage — last {args.days}d",
+        "",
+        f"- generated_utc: {dt.datetime.now(dt.timezone.utc).isoformat(timespec='seconds')}",
+        f"- agent: {args.agent} | jobs with runs: {len(per_job)} | total runs: {runs_total}",
+        f"- **CLOUD total (paid): {fmt(cloud_total)} tok**",
+        f"- **LOCAL total (free / offloaded): {fmt(local_total)} tok**",
+        "",
+        "| job | models (provider:model) | runs | ok | err | cloud_tok | local_tok |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for a in per_job:
+        models = ", ".join(sorted(a["models"]))
+        lines.append(
+            f"| {a['name']} | {models} | {a['runs']} | {a['ok']} | {a['err']} "
+            f"| {fmt(a['cloud_tok'])} | {fmt(a['local_tok'])} |"
+        )
+    lines += [
+        "",
+        "_CLOUD = 実際に課金されるトークン。LOCAL = ローカルollamaで処理した分（無料 / クラウドに払わずに済んだ分）。_",
+        "_1ジョブに複数モデルが並ぶ場合、期間内でモデルが切り替わった（例: cloud→local 移行 or フォールバック）ことを示す。_",
+    ]
+    report = "\n".join(lines)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report + "\n")
+
+    # Compact WhatsApp digest.
+    cloud_jobs = [a for a in per_job if a["cloud_tok"] > 0]
+    local_jobs = [a for a in per_job if a["local_tok"] > 0]
+    top_cloud = ", ".join(f"{a['name']}={fmt(a['cloud_tok'])}" for a in cloud_jobs[:3]) or "なし"
+    digest = (
+        f"📊 監視cron トークン使用 (直近{args.days}日)\n"
+        f"☁️ cloud(課金): {fmt(cloud_total)} tok / {len(cloud_jobs)}ジョブ\n"
+        f"✅ local(節約): {fmt(local_total)} tok / {len(local_jobs)}ジョブ\n"
+        f"cloud上位: {top_cloud}"
+    )
+
+    delivered = False
+    if args.deliver and args.to:
+        delivered = deliver_whatsapp(args.to, digest)
+
+    print(report)
+    print(f"\n[cloud={fmt(cloud_total)} local={fmt(local_total)} runs={runs_total} delivered={delivered} wrote={args.output}]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval-cases/cases.json
+++ b/scripts/eval-cases/cases.json
@@ -1,0 +1,416 @@
+{
+  "_comment": "Golden test set for ollama-summary-eval. SYNTHETIC/anonymized repos only (no private names) so the set is committable and safe to send to a cloud judge. Each case provides `rows` in the same schema as monitoring/private-health.json; the harness computes the ground truth from `rows` via expected(). Add hard cases here to make the eval more discriminating. Editing this file changes the fingerprint and triggers a re-run.",
+  "schema_version": 2,
+  "cases": [
+    {
+      "name": "easy-single-red",
+      "description": "Baseline: 1 RED (clear urgent via dependabot alerts), no YELLOW, several GREEN. Most models should ace this.",
+      "rows": [
+        {
+          "repo": "acme/payments-api",
+          "status": "RED",
+          "security": { "dependabot_alerts": 4 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 9 },
+          "issues": { "open_count": 12 },
+          "pull_requests": { "open_count": 3 }
+        },
+        {
+          "repo": "acme/web-dashboard",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 1 },
+          "issues": { "open_count": 4 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "acme/mobile-app",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 2 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "acme/docs-site",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 5 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "acme/infra-tf",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 3 },
+          "issues": { "open_count": 0 },
+          "pull_requests": { "open_count": 0 }
+        }
+      ]
+    },
+    {
+      "name": "multi-red-alert-tiebreak",
+      "description": "Three REDs. Urgent must be the RED with the most dependabot alerts (alerts outrank ci and inactivity in urgency_key). Catches models that just pick the first RED.",
+      "rows": [
+        {
+          "repo": "globex/auth-service",
+          "status": "RED",
+          "security": { "dependabot_alerts": 2 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 40 },
+          "issues": { "open_count": 8 },
+          "pull_requests": { "open_count": 2 }
+        },
+        {
+          "repo": "globex/billing-core",
+          "status": "RED",
+          "security": { "dependabot_alerts": 11 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 4 },
+          "issues": { "open_count": 5 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "globex/notify-worker",
+          "status": "RED",
+          "security": { "dependabot_alerts": 1 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 60 },
+          "issues": { "open_count": 3 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "globex/ui-kit",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "skipped" },
+          "activity": { "days_inactive": 20 },
+          "issues": { "open_count": 6 },
+          "pull_requests": { "open_count": 4 }
+        },
+        {
+          "repo": "globex/landing",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 2 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "globex/analytics",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 7 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 1 }
+        }
+      ]
+    },
+    {
+      "name": "alerts-vs-ci-priority",
+      "description": "Two REDs: one with ci=failure but 0 alerts, one with 7 alerts but ci=success. urgency_key ranks alerts above ci, so urgent = the 7-alerts repo. Tests precise tiebreak ordering and security-first reasoning.",
+      "rows": [
+        {
+          "repo": "initech/gateway",
+          "status": "RED",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 3 },
+          "issues": { "open_count": 9 },
+          "pull_requests": { "open_count": 2 }
+        },
+        {
+          "repo": "initech/datastore",
+          "status": "RED",
+          "security": { "dependabot_alerts": 7 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 1 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "initech/cron-jobs",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 6 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "initech/portal",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 4 },
+          "issues": { "open_count": 3 },
+          "pull_requests": { "open_count": 1 }
+        }
+      ]
+    },
+    {
+      "name": "many-yellow-watch-completeness",
+      "description": "1 RED, 5 YELLOW, 2 GREEN. The Watch line must list ALL five YELLOW repos. Catches models that truncate or drop YELLOW entries.",
+      "rows": [
+        {
+          "repo": "umbrella/core-api",
+          "status": "RED",
+          "security": { "dependabot_alerts": 3 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 15 },
+          "issues": { "open_count": 10 },
+          "pull_requests": { "open_count": 2 }
+        },
+        {
+          "repo": "umbrella/search",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "skipped" },
+          "activity": { "days_inactive": 25 },
+          "issues": { "open_count": 7 },
+          "pull_requests": { "open_count": 3 }
+        },
+        {
+          "repo": "umbrella/recommend",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 1 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 30 },
+          "issues": { "open_count": 4 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "umbrella/ingest",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "none" },
+          "activity": { "days_inactive": 18 },
+          "issues": { "open_count": 5 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "umbrella/scheduler",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 22 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 2 }
+        },
+        {
+          "repo": "umbrella/reporting",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "skipped" },
+          "activity": { "days_inactive": 28 },
+          "issues": { "open_count": 6 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "umbrella/static-cdn",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 2 },
+          "issues": { "open_count": 0 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "umbrella/edge-fn",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 5 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        }
+      ]
+    },
+    {
+      "name": "all-green-no-urgent",
+      "description": "Zero RED, zero YELLOW, all GREEN. There is no real urgent repo; a good summary says so (なし/特になし) rather than inventing a crisis. Tests over-alerting.",
+      "rows": [
+        {
+          "repo": "hooli/api-core",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 1 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "hooli/frontend",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 2 },
+          "issues": { "open_count": 3 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "hooli/mobile",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 4 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "hooli/infra",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 3 },
+          "issues": { "open_count": 0 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "hooli/ml-pipeline",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 6 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "hooli/docs",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 8 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        }
+      ]
+    },
+    {
+      "name": "empty-no-repos",
+      "description": "No repos at all. Counts must be RED 0 / YELLOW 0 / GREEN 0 and the summary must NOT invent any repo name. Tests hallucination and graceful degenerate handling.",
+      "rows": []
+    },
+    {
+      "name": "large-mixed-status-priority",
+      "description": "12 repos, 2 RED / 4 YELLOW / 6 GREEN, plus GREEN repos that have noisy ci=failure. Urgent must be a RED; ci-noisy GREEN repos must NOT be put on Watch. Tests counting at scale + status priority over ci noise.",
+      "rows": [
+        {
+          "repo": "stark/reactor-api",
+          "status": "RED",
+          "security": { "dependabot_alerts": 6 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 12 },
+          "issues": { "open_count": 14 },
+          "pull_requests": { "open_count": 3 }
+        },
+        {
+          "repo": "stark/suit-firmware",
+          "status": "RED",
+          "security": { "dependabot_alerts": 2 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 50 },
+          "issues": { "open_count": 7 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "stark/jarvis-nlp",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 1 },
+          "ci": { "last_status": "skipped" },
+          "activity": { "days_inactive": 21 },
+          "issues": { "open_count": 5 },
+          "pull_requests": { "open_count": 2 }
+        },
+        {
+          "repo": "stark/comms",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 26 },
+          "issues": { "open_count": 3 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "stark/telemetry",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "none" },
+          "activity": { "days_inactive": 19 },
+          "issues": { "open_count": 4 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "stark/ui-shell",
+          "status": "YELLOW",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "skipped" },
+          "activity": { "days_inactive": 24 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 3 }
+        },
+        {
+          "repo": "stark/billing",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 3 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "stark/auth",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "failure" },
+          "activity": { "days_inactive": 4 },
+          "issues": { "open_count": 2 },
+          "pull_requests": { "open_count": 1 }
+        },
+        {
+          "repo": "stark/cdn-edge",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 1 },
+          "issues": { "open_count": 0 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "stark/data-lake",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 6 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "stark/scheduler",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 5 },
+          "issues": { "open_count": 0 },
+          "pull_requests": { "open_count": 0 }
+        },
+        {
+          "repo": "stark/docs-portal",
+          "status": "GREEN",
+          "security": { "dependabot_alerts": 0 },
+          "ci": { "last_status": "success" },
+          "activity": { "days_inactive": 9 },
+          "issues": { "open_count": 1 },
+          "pull_requests": { "open_count": 0 }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ollama-summary-eval
+++ b/scripts/ollama-summary-eval
@@ -637,20 +637,25 @@ def run_eval(args: argparse.Namespace) -> int:
 
     unload_models(host, models + args.extra_unload_models)
 
-    # Persist fingerprint of this real run for the staleness gate.
+    scored = [r for r in records if r["total_score"] is not None]
+    if not scored:
+        # Judge unavailable → every record is unscored. Do NOT cache the
+        # freshness fingerprint, or --skip-if-unchanged would skip retries for
+        # up to --max-stale-days and leave the recommendation stale/missing.
+        # Return non-zero so the cron surfaces the unscored run.
+        print("best=n/a (no scored records — judge unavailable; fingerprint NOT cached, will retry)", file=sys.stderr)
+        return 1
+
+    # Only cache the fingerprint for a genuinely scored run.
     args.fingerprint_file.parent.mkdir(parents=True, exist_ok=True)
     args.fingerprint_file.write_text(json.dumps({"fingerprint": fingerprint, "ts": ts}, ensure_ascii=False) + "\n")
 
-    scored = [r for r in records if r["total_score"] is not None]
-    if scored:
-        by_model: dict[str, list[float]] = {}
-        for r in scored:
-            by_model.setdefault(r["model"], []).append(r["total_score"])
-        ranked = sorted(by_model.items(), key=lambda kv: statistics.mean(kv[1]), reverse=True)
-        best, best_scores = ranked[0]
-        print(f"best={best} avg_total={statistics.mean(best_scores):.2f}/10 (cases={len(best_scores)})")
-    else:
-        print("best=n/a (no scored records — judge unavailable?)")
+    by_model: dict[str, list[float]] = {}
+    for r in scored:
+        by_model.setdefault(r["model"], []).append(r["total_score"])
+    ranked = sorted(by_model.items(), key=lambda kv: statistics.mean(kv[1]), reverse=True)
+    best, best_scores = ranked[0]
+    print(f"best={best} avg_total={statistics.mean(best_scores):.2f}/10 (cases={len(best_scores)})")
     return 0
 
 

--- a/scripts/ollama-summary-eval
+++ b/scripts/ollama-summary-eval
@@ -1,25 +1,46 @@
 #!/usr/bin/env python3
-"""Evaluate local Ollama models for private repo health summaries.
+"""Evaluate local Ollama models for repo-health summaries.
 
-The input and outputs include private repo names, so write only to gitignored
-monitoring files. This script intentionally uses Ollama's native /api/chat
-endpoint so `think:false` and `num_ctx` are honored for Gemma/Qwen models.
+Scoring is HYBRID (total 0-10):
+  - deterministic ground-truth checks (0-6): counts, urgent line, urgent reason
+    grounding, Watch completeness/hygiene, required sections, length, and
+    hallucinated-repo detection. Reproducible, free, runs offline.
+  - LLM judge (0-4): a strong *cloud* model (distinct from every candidate)
+    grades the qualitative dimensions the rules cannot — reason accuracy,
+    action usefulness, conciseness/clarity — against the ground truth. Judged
+    `--judge-samples` times and the per-dimension median is taken to damp
+    cloud-judge nondeterminism.
+
+Input is a GOLDEN SET of fixed, anonymized cases (scripts/eval-cases/cases.json)
+covering a difficulty gradient, so the score discriminates and is stable across
+runs regardless of when the live repo scan last ran. The cases are synthetic
+(no private repo names) and therefore safe to send to a cloud judge.
+
+The candidate models are queried via Ollama's native /api/chat (so think:false
+and num_ctx are honored). The judge is invoked via `openclaw infer model run`.
+
+A fingerprint of {models, cases, judge model, scoring version} gates re-runs:
+with --skip-if-unchanged the job no-ops unless something changed OR the last
+real run is older than --max-stale-days. This kills the old daily-redundancy
+problem (temperature=0 + frozen input = identical output every day).
 """
 
 from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import os
 import re
 import statistics
+import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 DEFAULT_HOST = "http://100.86.194.4:11434"
@@ -29,8 +50,20 @@ DEFAULT_MODELS = [
     "glm4:9b",
     "qwen3.5:4b-mlx",
 ]
+# Judge must be a strong cloud model that is NOT one of the candidates, to avoid
+# self-grading bias. Overridable with --judge-model.
+DEFAULT_JUDGE_MODEL = "openai/gpt-5.4"
+CASES_FILE = Path("scripts/eval-cases/cases.json")
 OUTPUT_JSONL = Path("monitoring/ollama-summary-eval.jsonl")
 OUTPUT_REPORT = Path("monitoring/ollama-summary-eval-report.md")
+FINGERPRINT_FILE = Path("monitoring/ollama-summary-eval.fingerprint.json")
+
+# Bump when the scoring logic changes so the fingerprint invalidates and the
+# report can distinguish score scales across versions.
+SCORING_VERSION = 2
+DET_MAX = 6.0
+LLM_MAX = 4.0
+TOTAL_MAX = DET_MAX + LLM_MAX  # 10
 
 
 def now_utc() -> dt.datetime:
@@ -56,13 +89,77 @@ def unload_models(host: str, models: list[str], timeout: int = 30) -> None:
             pass
 
 
+# ---------------------------------------------------------------------------
+# Inputs: golden cases + (optional) live health file
+# ---------------------------------------------------------------------------
+def load_cases(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise SystemExit(f"missing golden cases file: {path}")
+    data = json.loads(path.read_text())
+    cases = data.get("cases") if isinstance(data, dict) else data
+    if not isinstance(cases, list) or not cases:
+        raise SystemExit(f"cases file has no `cases` array: {path}")
+    norm = []
+    for case in cases:
+        norm.append(
+            {
+                "name": str(case.get("name", "unnamed")),
+                "description": str(case.get("description", "")),
+                "rows": list(case.get("rows", [])),
+            }
+        )
+    return norm
+
+
+def canonical_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a health row to the nested schema the scorer expects.
+
+    scripts/repo-health emits the nested form (security.dependabot_alerts,
+    ci.last_status, activity.days_inactive, issues.open_count,
+    pull_requests.open_count). Older private-health.json snapshots used a flat
+    form (dependabot_alerts?, ci_status, days_inactive, open_issues, open_prs).
+    Accept either so the same code grades golden cases, live snapshots, and
+    legacy files.
+    """
+    def pick(*paths: str, default: Any = None) -> Any:
+        for p in paths:
+            val = row_value(row, p, None)
+            if val is not None:
+                return val
+        return default
+
+    return {
+        "repo": row.get("repo", ""),
+        "status": row.get("status", "UNKNOWN"),
+        "security": {"dependabot_alerts": int(pick("security.dependabot_alerts", "dependabot_alerts", default=0) or 0)},
+        "ci": {"last_status": str(pick("ci.last_status", "ci_status", default="unknown"))},
+        "activity": {"days_inactive": int(pick("activity.days_inactive", "days_inactive", default=0) or 0)},
+        "issues": {"open_count": int(pick("issues.open_count", "open_issues", default=0) or 0)},
+        "pull_requests": {"open_count": int(pick("pull_requests.open_count", "open_prs", default=0) or 0)},
+    }
+
+
+def normalize_health_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [canonical_row(r) for r in rows]
+
+
 def load_health(path: Path) -> list[dict[str, Any]]:
     if not path.is_file():
-        raise SystemExit(f"missing private health file: {path}")
+        raise SystemExit(f"missing health file: {path}")
     data = json.loads(path.read_text())
     if not isinstance(data, list):
-        raise SystemExit(f"private health file must be a JSON array: {path}")
-    return data
+        raise SystemExit(f"health file must be a JSON array: {path}")
+    return normalize_health_rows(data)
+
+
+def read_recommended_model(report_path: Path, default: str) -> str:
+    """Return the model recommended by the latest eval report, else default."""
+    if not report_path.is_file():
+        return default
+    m = re.search(r"recommended_for_repo_health_summary:\s*(\S+)", report_path.read_text())
+    if not m or m.group(1) in {"n/a", "none", ""}:
+        return default
+    return m.group(1)
 
 
 def row_value(row: dict[str, Any], dotted: str, default: Any = None) -> Any:
@@ -75,19 +172,16 @@ def row_value(row: dict[str, Any], dotted: str, default: Any = None) -> Any:
 
 
 def health_tsv(rows: list[dict[str, Any]]) -> str:
-    lines = [
-        "\t".join(
-            [
-                "repo",
-                "status",
-                "dependabot_alerts",
-                "ci_status",
-                "days_inactive",
-                "open_issues",
-                "open_prs",
-            ]
-        )
+    header = [
+        "repo",
+        "status",
+        "dependabot_alerts",
+        "ci_status",
+        "days_inactive",
+        "open_issues",
+        "open_prs",
     ]
+    lines = ["\t".join(header)]
     for row in rows:
         lines.append(
             "\t".join(
@@ -105,6 +199,9 @@ def health_tsv(rows: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+CI_BAD = {"failure", "skipped", "none"}
+
+
 def expected(rows: list[dict[str, Any]]) -> dict[str, Any]:
     statuses = {"RED": [], "YELLOW": [], "GREEN": []}
     for row in rows:
@@ -115,14 +212,25 @@ def expected(rows: list[dict[str, Any]]) -> dict[str, Any]:
     def urgency_key(row: dict[str, Any]) -> tuple[int, int, int, int]:
         status_rank = {"RED": 3, "YELLOW": 2, "GREEN": 1}.get(str(row.get("status")), 0)
         alerts = int(row_value(row, "security.dependabot_alerts", 0) or 0)
-        ci_bad = 1 if str(row_value(row, "ci.last_status", "")) in {"failure", "skipped", "none"} else 0
+        ci_bad = 1 if str(row_value(row, "ci.last_status", "")) in CI_BAD else 0
         inactive = int(row_value(row, "activity.days_inactive", 0) or 0)
         return (status_rank, alerts, ci_bad, inactive)
 
-    urgent = max(rows, key=urgency_key)["repo"] if rows else ""
+    urgent_row = max(rows, key=urgency_key) if rows else None
+    urgent = urgent_row["repo"] if urgent_row else ""
+    has_red = bool(statuses["RED"])
+    # Driver behind the urgent repo, used to grade reason grounding.
+    driver = None
+    if urgent_row is not None:
+        if int(row_value(urgent_row, "security.dependabot_alerts", 0) or 0) > 0:
+            driver = "alerts"
+        elif str(row_value(urgent_row, "ci.last_status", "")) in CI_BAD:
+            driver = "ci"
     return {
         "counts": {k: len(v) for k, v in statuses.items()},
         "urgent": urgent,
+        "urgent_driver": driver,
+        "has_red": has_red,
         "yellow": statuses["YELLOW"],
         "green": statuses["GREEN"],
     }
@@ -141,169 +249,408 @@ Next: <次の1アクション>
 制約:
 - GREENをWatchに入れない
 - 最緊急はREDかつdependabot_alerts/ci_statusを重視
+- REDが無い場合 Urgent は「なし」とする
+- 入力に無いリポ名を出さない
 - 120〜180字程度
 
 TSV:
 {tsv}"""
 
 
-def names_for(repo: str) -> set[str]:
+# ---------------------------------------------------------------------------
+# Deterministic scoring (0-6)
+# ---------------------------------------------------------------------------
+def repo_names(repo: str) -> set[str]:
     base = repo.rsplit("/", 1)[-1]
     return {repo, base}
 
 
+def all_input_names(rows: list[dict[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for row in rows:
+        repo = str(row.get("repo", ""))
+        if repo:
+            names |= repo_names(repo)
+    return names
+
+
 def contains_repo(text: str, repo: str) -> bool:
-    # Empty repo would make `"" in text` always True; guard against false positives.
     if not repo:
         return False
-    return any(name in text for name in names_for(repo))
+    return any(name in text for name in repo_names(repo))
 
 
-def evaluate_text(text: str, exp: dict[str, Any]) -> dict[str, Any]:
-    count_match = re.search(
-        r"RED\s*(\d+)\s*/\s*YELLOW\s*(\d+)\s*/\s*GREEN\s*(\d+)", text, re.I
-    )
+def section_line(text: str, header: str) -> Optional[str]:
+    match = re.search(rf"^{header}\s*[:：]\s*(.*)$", text, re.I | re.M)
+    return match.group(1).strip() if match else None
+
+
+NONE_WORDS = ("なし", "無し", "特になし", "無", "none", "n/a", "no urgent")
+SLUG_RE = re.compile(r"[A-Za-z0-9][\w.\-]*\/[A-Za-z0-9][\w.\-]+")
+REASON_WORDS = {
+    "alerts": ("alert", "アラート", "依存", "dependabot", "脆弱", "security", "セキュリティ", "cve"),
+    "ci": ("ci", "ビルド", "build", "失敗", "テスト", "test", "pipeline", "パイプ"),
+}
+
+
+def evaluate_deterministic(text: str, exp: dict[str, Any], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return per-check booleans (None = not applicable) and a 0-6 score."""
+    checks: dict[str, Optional[bool]] = {}
+
+    # 1. counts
+    m = re.search(r"RED\s*(\d+)\s*/\s*YELLOW\s*(\d+)\s*/\s*GREEN\s*(\d+)", text, re.I)
     parsed_counts = None
-    counts_correct = False
-    if count_match:
-        parsed_counts = {
-            "RED": int(count_match.group(1)),
-            "YELLOW": int(count_match.group(2)),
-            "GREEN": int(count_match.group(3)),
-        }
-        counts_correct = parsed_counts == exp["counts"]
+    if m:
+        parsed_counts = {"RED": int(m.group(1)), "YELLOW": int(m.group(2)), "GREEN": int(m.group(3))}
+    checks["counts_correct"] = parsed_counts == exp["counts"]
 
-    urgent_correct = contains_repo(text, exp["urgent"])
-    watch_match = re.search(r"^Watch:\s*(.+)$", text, re.I | re.M)
-    watch_text = watch_match.group(1) if watch_match else text
-    yellow_missing = [repo for repo in exp["yellow"] if not contains_repo(watch_text, repo)]
-    green_in_watch = [repo for repo in exp["green"] if contains_repo(watch_text, repo)]
-    yellow_correct = not yellow_missing
-    watch_clean = not green_in_watch
+    # 2. required sections present
+    headers = ["Summary", "Urgent", "Watch", "Stable", "Next"]
+    checks["sections_present"] = all(section_line(text, h) is not None for h in headers)
 
-    checks = {
-        "counts_correct": counts_correct,
-        "urgent_correct": urgent_correct,
-        "yellow_correct": yellow_correct,
-        "watch_clean": watch_clean,
-    }
+    urgent_line = section_line(text, "Urgent") or ""
+    watch_line = section_line(text, "Watch") or ""
+
+    # 3. urgent named in the Urgent line specifically (lenient when no RED)
+    if exp["has_red"] and exp["urgent"]:
+        checks["urgent_in_urgent_line"] = contains_repo(urgent_line, exp["urgent"])
+    elif not exp["yellow"] and not exp["green"] and not exp["has_red"]:
+        # empty case: Urgent should say "none"
+        low = urgent_line.lower()
+        checks["urgent_in_urgent_line"] = any(w in low for w in NONE_WORDS)
+    else:
+        # all-green / no-red: "なし" OR the computed (lowest-severity) urgent is acceptable
+        low = urgent_line.lower()
+        checks["urgent_in_urgent_line"] = (
+            any(w in low for w in NONE_WORDS) or contains_repo(urgent_line, exp["urgent"])
+        )
+
+    # 4. urgent reason grounded in the real driver (N/A if no driver)
+    if exp["has_red"] and exp["urgent_driver"]:
+        low = urgent_line.lower()
+        checks["urgent_reason_grounded"] = any(w in low for w in REASON_WORDS[exp["urgent_driver"]])
+    else:
+        checks["urgent_reason_grounded"] = None
+
+    # 5. Watch completeness: all YELLOW present (N/A if no YELLOW)
+    if exp["yellow"]:
+        missing = [r for r in exp["yellow"] if not contains_repo(watch_line, r)]
+        checks["watch_complete"] = not missing
+    else:
+        checks["watch_complete"] = None
+
+    # 6. Watch hygiene: no GREEN leaked into Watch
+    green_in_watch = [r for r in exp["green"] if contains_repo(watch_line, r)]
+    checks["watch_clean"] = not green_in_watch
+
+    # 7. length within a tolerant band around the 120-180 target
+    n = len(text.strip())
+    checks["length_ok"] = 90 <= n <= 240
+
+    # 8. no hallucinated repo slug (every owner/name token must be a real input)
+    allowed = all_input_names(rows)
+    slugs = {s for s in SLUG_RE.findall(text)}
+    hallucinated = sorted(s for s in slugs if s not in allowed and s.rsplit("/", 1)[-1] not in allowed)
+    checks["no_hallucinated_repo"] = not hallucinated
+
+    applicable = [v for v in checks.values() if v is not None]
+    passed = sum(1 for v in applicable if v)
+    det_score = round((passed / len(applicable)) * DET_MAX, 3) if applicable else 0.0
     return {
-        "score": sum(1 for value in checks.values() if value),
-        "max_score": len(checks),
+        "det_score": det_score,
+        "det_max": DET_MAX,
         "checks": checks,
         "parsed_counts": parsed_counts,
-        "yellow_missing": yellow_missing,
-        "green_in_watch": green_in_watch,
-        "watch_text": watch_text,
+        "hallucinated": hallucinated,
+        "passed": passed,
+        "applicable": len(applicable),
     }
 
 
-def run_model(
-    host: str,
-    model: str,
-    prompt: str,
+# ---------------------------------------------------------------------------
+# LLM judge (0-4) via `openclaw infer model run`
+# ---------------------------------------------------------------------------
+JUDGE_DIMS = ("reason_accuracy", "action_usefulness", "conciseness_clarity")
+
+
+def build_judge_prompt(case: dict[str, Any], summary: str, exp: dict[str, Any], tsv: str) -> str:
+    truth = {
+        "counts": exp["counts"],
+        "expected_urgent_repo": exp["urgent"] or "(none / all healthy)",
+        "expected_urgent_driver": exp["urgent_driver"] or "(none)",
+        "yellow_repos": exp["yellow"],
+    }
+    return f"""You are a strict evaluator grading a Japanese repo-health summary produced by a small model.
+
+You are given (a) the source data, (b) the verified ground truth, and (c) the candidate summary.
+The factual parts (counts, which repo is urgent, which are on watch) are ALREADY checked elsewhere.
+Grade ONLY the qualitative quality, each 0-5 (integers):
+
+- reason_accuracy: Is the stated reason for the Urgent repo consistent with the data and the
+  expected driver? Penalize reasons that are wrong, vague, or contradicted by the data.
+- action_usefulness: Is the "Next" action specific, relevant to the real top problem, and actionable?
+  Penalize generic filler ("確認する" with no object) or actions aimed at the wrong repo.
+- conciseness_clarity: Is it within ~120-180 Japanese characters, well-structured, and unambiguous?
+  Penalize redundancy, padding, broken format, or confusing wording.
+
+Return ONLY a JSON object, no markdown, no prose:
+{{"reason_accuracy": <0-5>, "action_usefulness": <0-5>, "conciseness_clarity": <0-5>, "notes": "<= 20 words"}}
+
+## Source data (TSV)
+{tsv}
+
+## Ground truth
+{json.dumps(truth, ensure_ascii=False)}
+
+## Candidate summary
+{summary}
+"""
+
+
+def _extract_json(text: str) -> Optional[dict[str, Any]]:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text).strip()
+    dec = json.JSONDecoder()
+    start = text.find("{")
+    while start != -1:
+        try:
+            obj, _ = dec.raw_decode(text, start)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+        start = text.find("{", start + 1)
+    return None
+
+
+def judge_once(prompt: str, judge_model: str, timeout: int) -> Optional[dict[str, Any]]:
+    try:
+        proc = subprocess.run(
+            ["openclaw", "infer", "model", "run", "--model", judge_model, "--json", "--prompt", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if proc.returncode != 0:
+        return None
+    wrapper = _extract_json(proc.stdout)
+    if not wrapper:
+        return None
+    outputs = wrapper.get("outputs") or []
+    if not outputs:
+        return None
+    rubric = _extract_json(str(outputs[0].get("text", "")))
+    if not rubric:
+        return None
+    out: dict[str, Any] = {}
+    for dim in JUDGE_DIMS:
+        try:
+            val = float(rubric[dim])
+        except (KeyError, TypeError, ValueError):
+            return None
+        out[dim] = max(0.0, min(5.0, val))
+    out["notes"] = str(rubric.get("notes", ""))[:120]
+    return out
+
+
+def run_judge(
+    case: dict[str, Any],
+    summary: str,
     exp: dict[str, Any],
-    num_ctx: int,
+    tsv: str,
+    judge_model: str,
+    samples: int,
     timeout: int,
 ) -> dict[str, Any]:
+    prompt = build_judge_prompt(case, summary, exp, tsv)
+    runs = [judge_once(prompt, judge_model, timeout) for _ in range(max(1, samples))]
+    good = [r for r in runs if r]
+    if not good:
+        return {"ok": False, "error": "judge_failed", "llm_score": None, "dims": None, "samples": 0}
+    dims = {dim: round(statistics.median(r[dim] for r in good), 3) for dim in JUDGE_DIMS}
+    llm_score = round((sum(dims.values()) / (len(JUDGE_DIMS) * 5.0)) * LLM_MAX, 3)
+    return {
+        "ok": True,
+        "error": None,
+        "llm_score": llm_score,
+        "dims": dims,
+        "samples": len(good),
+        "notes": [r.get("notes", "") for r in good],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Candidate model call
+# ---------------------------------------------------------------------------
+def run_model(host: str, model: str, prompt: str, num_ctx: int, timeout: int) -> dict[str, Any]:
     payload = {
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "stream": False,
         "think": False,
         "keep_alive": "0",
-        "options": {
-            "temperature": 0,
-            "num_ctx": num_ctx,
-            "num_predict": 240,
-        },
+        "options": {"temperature": 0, "num_ctx": num_ctx, "num_predict": 240},
     }
     started = time.time()
     try:
         body = post_json(host, "/api/chat", payload, timeout)
         elapsed = time.time() - started
-        message = body.get("message") or {}
-        text = (message.get("content") or "").strip()
+        text = ((body.get("message") or {}).get("content") or "").strip()
         eval_count = int(body.get("eval_count") or 0)
         eval_duration = int(body.get("eval_duration") or 0)
         prompt_eval_count = int(body.get("prompt_eval_count") or 0)
-        prompt_eval_duration = int(body.get("prompt_eval_duration") or 0)
-        result = {
+        return {
             "ok": bool(text),
             "error": None if text else "empty_response",
             "seconds": round(elapsed, 2),
             "prompt_tokens": prompt_eval_count,
             "output_tokens": eval_count,
-            "tok_s": round(eval_count / (eval_duration / 1e9), 2)
-            if eval_duration
-            else None,
-            "prompt_tok_s": round(prompt_eval_count / (prompt_eval_duration / 1e9), 2)
-            if prompt_eval_duration
-            else None,
+            "tok_s": round(eval_count / (eval_duration / 1e9), 2) if eval_duration else None,
             "summary": text,
         }
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        result = {
+        return {
             "ok": False,
             "error": repr(exc),
             "seconds": round(time.time() - started, 2),
             "prompt_tokens": 0,
             "output_tokens": 0,
             "tok_s": None,
-            "prompt_tok_s": None,
             "summary": "",
         }
 
-    result["evaluation"] = evaluate_text(result["summary"], exp) if result["ok"] else None
-    return result
+
+# ---------------------------------------------------------------------------
+# Fingerprint / staleness gate
+# ---------------------------------------------------------------------------
+def compute_fingerprint(cases: list[dict[str, Any]], models: list[str], judge_model: str, samples: int, no_judge: bool) -> str:
+    blob = json.dumps(
+        {
+            "scoring_version": SCORING_VERSION,
+            "models": sorted(models),
+            "judge_model": "none" if no_judge else judge_model,
+            "judge_samples": 0 if no_judge else samples,
+            "cases": cases,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+def should_skip(fp_path: Path, fingerprint: str, max_stale_days: int) -> Optional[str]:
+    if not fp_path.is_file():
+        return None
+    try:
+        state = json.loads(fp_path.read_text())
+        last_ts = dt.datetime.fromisoformat(state["ts"])
+    except Exception:
+        return None
+    if state.get("fingerprint") != fingerprint:
+        return None
+    age_days = (now_utc() - last_ts).total_seconds() / 86400
+    if age_days >= max_stale_days:
+        return None
+    return f"unchanged since {state['ts']} (age {age_days:.1f}d < {max_stale_days}d)"
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
 def run_eval(args: argparse.Namespace) -> int:
     host = args.host
     models = args.models
-    unload_models(host, models + args.extra_unload_models)
-    rows = load_health(args.health_file)
-    exp = expected(rows)
-    prompt = build_prompt(health_tsv(rows))
-    ts = now_utc().isoformat()
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-
-    records = []
-    for model in models:
-        unload_models(host, models + args.extra_unload_models)
-        result = run_model(host, model, prompt, exp, args.num_ctx, args.timeout)
-        record = {
-            "ts": ts,
-            "host": host,
-            "model": model,
-            "num_ctx": args.num_ctx,
-            "health_file": str(args.health_file),
-            "health_checked_at": sorted({row.get("checked_at") for row in rows if row.get("checked_at")}),
-            "expected": exp,
-            **result,
-        }
-        records.append(record)
-        with args.output.open("a") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
-        score = record["evaluation"]["score"] if record.get("evaluation") else 0
-        print(
-            f"{model}: ok={record['ok']} score={score}/4 "
-            f"seconds={record['seconds']} tok_s={record['tok_s']}"
+    cases = load_cases(args.cases)
+    if args.health_file:
+        cases.append(
+            {
+                "name": "live-private-health",
+                "description": "Live snapshot appended at runtime (not in golden set).",
+                "rows": load_health(args.health_file),
+            }
         )
 
+    fingerprint = compute_fingerprint(cases, models, args.judge_model, args.judge_samples, args.no_judge)
+    if args.skip_if_unchanged:
+        reason = should_skip(args.fingerprint_file, fingerprint, args.max_stale_days)
+        if reason:
+            print(f"SKIP: {reason}")
+            return 0
+
+    ts = now_utc().isoformat()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict[str, Any]] = []
+
+    for case in cases:
+        rows = case["rows"]
+        exp = expected(rows)
+        tsv = health_tsv(rows)
+        prompt = build_prompt(tsv)
+        for model in models:
+            unload_models(host, models + args.extra_unload_models)
+            res = run_model(host, model, prompt, args.num_ctx, args.timeout)
+            det = evaluate_deterministic(res["summary"], exp, rows) if res["ok"] else None
+            judge = None
+            if res["ok"] and not args.no_judge:
+                judge = run_judge(case, res["summary"], exp, tsv, args.judge_model, args.judge_samples, args.judge_timeout)
+
+            det_score = det["det_score"] if det else 0.0
+            llm_score = judge["llm_score"] if (judge and judge["ok"]) else None
+            total = round(det_score + llm_score, 3) if llm_score is not None else None
+
+            record = {
+                "ts": ts,
+                "schema": SCORING_VERSION,
+                "host": host,
+                "model": model,
+                "case": case["name"],
+                "num_ctx": args.num_ctx,
+                "expected": {k: exp[k] for k in ("counts", "urgent", "urgent_driver", "yellow")},
+                "judge_model": None if args.no_judge else args.judge_model,
+                **res,
+                "deterministic": det,
+                "judge": judge,
+                "det_score": det_score,
+                "llm_score": llm_score,
+                "total_score": total,
+                "total_max": TOTAL_MAX,
+            }
+            records.append(record)
+            with args.output.open("a") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            tstr = f"{total:.2f}" if total is not None else "n/a"
+            lstr = f"{llm_score:.2f}" if llm_score is not None else "n/a"
+            print(
+                f"[{case['name']}] {model}: ok={res['ok']} "
+                f"det={det_score:.2f}/6 llm={lstr}/4 total={tstr}/10 {res['seconds']}s"
+            )
+
     unload_models(host, models + args.extra_unload_models)
-    best = sorted(
-        records,
-        key=lambda r: (
-            (r.get("evaluation") or {}).get("score", 0),
-            -float(r.get("seconds") or 9999),
-        ),
-        reverse=True,
-    )[0]
-    print(f"best={best['model']} score={(best.get('evaluation') or {}).get('score', 0)}/4")
+
+    # Persist fingerprint of this real run for the staleness gate.
+    args.fingerprint_file.parent.mkdir(parents=True, exist_ok=True)
+    args.fingerprint_file.write_text(json.dumps({"fingerprint": fingerprint, "ts": ts}, ensure_ascii=False) + "\n")
+
+    scored = [r for r in records if r["total_score"] is not None]
+    if scored:
+        by_model: dict[str, list[float]] = {}
+        for r in scored:
+            by_model.setdefault(r["model"], []).append(r["total_score"])
+        ranked = sorted(by_model.items(), key=lambda kv: statistics.mean(kv[1]), reverse=True)
+        best, best_scores = ranked[0]
+        print(f"best={best} avg_total={statistics.mean(best_scores):.2f}/10 (cases={len(best_scores)})")
+    else:
+        print("best=n/a (no scored records — judge unavailable?)")
     return 0
 
 
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
 def parse_jsonl(path: Path) -> list[dict[str, Any]]:
     records = []
     if not path.is_file():
@@ -320,70 +667,87 @@ def parse_jsonl(path: Path) -> list[dict[str, Any]]:
 
 def report(args: argparse.Namespace) -> int:
     cutoff = now_utc() - dt.timedelta(days=args.days)
-    records = []
-    for record in parse_jsonl(args.input):
+    all_records = parse_jsonl(args.input)
+    records, legacy = [], 0
+    for record in all_records:
+        if record.get("schema", 0) < SCORING_VERSION or "total_score" not in record:
+            legacy += 1
+            continue
         try:
-            record_ts = dt.datetime.fromisoformat(record["ts"])
+            if dt.datetime.fromisoformat(record["ts"]) >= cutoff:
+                records.append(record)
         except Exception:
             continue
-        if record_ts >= cutoff:
-            records.append(record)
 
     by_model: dict[str, list[dict[str, Any]]] = {}
     for record in records:
         by_model.setdefault(record["model"], []).append(record)
 
+    def mean(vals: list[float]) -> float:
+        return statistics.mean(vals) if vals else 0.0
+
     rows = []
-    for model, model_records in sorted(by_model.items()):
-        scores = [
-            (r.get("evaluation") or {}).get("score", 0)
-            for r in model_records
-            if r.get("ok")
-        ]
-        latencies = [float(r["seconds"]) for r in model_records if r.get("ok")]
-        failures = sum(1 for r in model_records if not r.get("ok"))
+    for model, recs in by_model.items():
+        ok = [r for r in recs if r.get("ok")]
+        totals = [r["total_score"] for r in ok if r.get("total_score") is not None]
+        dets = [r["det_score"] for r in ok if r.get("det_score") is not None]
+        llms = [r["llm_score"] for r in ok if r.get("llm_score") is not None]
         rows.append(
             {
                 "model": model,
-                "runs": len(model_records),
-                "failures": failures,
-                "avg_score": statistics.mean(scores) if scores else 0,
-                "perfect": sum(1 for score in scores if score == 4),
-                "avg_seconds": statistics.mean(latencies) if latencies else 0,
+                "cases": len(recs),
+                "failures": sum(1 for r in recs if not r.get("ok")),
+                "judge_na": sum(1 for r in ok if r.get("llm_score") is None),
+                "avg_total": mean(totals),
+                "avg_det": mean(dets),
+                "avg_llm": mean(llms),
+                "perfect": sum(1 for t in totals if t >= TOTAL_MAX - 1e-6),
+                "avg_seconds": mean([float(r["seconds"]) for r in ok if r.get("seconds") is not None]),
             }
         )
 
-    ranked = sorted(rows, key=lambda r: (r["avg_score"], r["perfect"], -r["avg_seconds"]), reverse=True)
+    ranked = sorted(rows, key=lambda r: (r["avg_total"], -r["avg_seconds"]), reverse=True)
     winner = ranked[0]["model"] if ranked else "n/a"
     generated = now_utc().isoformat()
 
     lines = [
-        f"# Ollama Summary Eval Report",
+        "# Ollama Summary Eval Report",
         "",
         f"- generated_at_utc: {generated}",
+        f"- scoring_version: {SCORING_VERSION} (hybrid: deterministic {DET_MAX:.0f} + LLM judge {LLM_MAX:.0f} = {TOTAL_MAX:.0f})",
         f"- window_days: {args.days}",
-        f"- records: {len(records)}",
+        f"- records: {len(records)} (legacy/older-schema skipped: {legacy})",
         f"- recommended_for_repo_health_summary: {winner}",
         "",
-        "| model | runs | failures | avg_score | perfect | avg_seconds |",
-        "| --- | ---: | ---: | ---: | ---: | ---: |",
+        "| model | cases | fail | judge_na | avg_total | avg_det | avg_llm | perfect | avg_sec |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
-    for row in ranked:
+    for r in ranked:
         lines.append(
-            "| {model} | {runs} | {failures} | {avg_score:.2f}/4 | {perfect} | {avg_seconds:.2f} |".format(
-                **row
-            )
+            "| {model} | {cases} | {failures} | {judge_na} | {avg_total:.2f}/10 | {avg_det:.2f}/6 "
+            "| {avg_llm:.2f}/4 | {perfect} | {avg_seconds:.2f} |".format(**r)
         )
 
-    latest_good = {}
-    for record in records:
-        if record.get("ok"):
-            latest_good[record["model"]] = record
-    if latest_good:
-        lines += ["", "## Latest Good Summaries", ""]
-        for model in sorted(latest_good):
-            summary = latest_good[model].get("summary", "").strip()
-            lines += [f"### {model}", "", "```text", summary, "```", ""]
+    # Per-case breakdown for the winner so weak spots are visible.
+    if winner != "n/a":
+        wrecs = [r for r in by_model.get(winner, []) if r.get("total_score") is not None]
+        if wrecs:
+            lines += ["", f"## Per-case totals — {winner}", "", "| case | total | det | llm |", "| --- | ---: | ---: | ---: |"]
+            for r in sorted(wrecs, key=lambda r: r["case"]):
+                lines.append(
+                    f"| {r['case']} | {r['total_score']:.2f} | {r['det_score']:.2f} | {r['llm_score']:.2f} |"
+                )
+
+    # Hardest cases across all models (lowest mean total) — where to focus.
+    by_case: dict[str, list[float]] = {}
+    for r in records:
+        if r.get("total_score") is not None:
+            by_case.setdefault(r["case"], []).append(r["total_score"])
+    if by_case:
+        hardest = sorted(by_case.items(), key=lambda kv: mean(kv[1]))[:5]
+        lines += ["", "## Hardest cases (lowest mean total across models)", "", "| case | mean_total | n |", "| --- | ---: | ---: |"]
+        for case, vals in hardest:
+            lines.append(f"| {case} | {mean(vals):.2f} | {len(vals)} |")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text("\n".join(lines).rstrip() + "\n")
@@ -396,9 +760,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    run_p = sub.add_parser("run", help="Run one model comparison and append JSONL")
+    run_p = sub.add_parser("run", help="Run the golden-set comparison and append JSONL")
     run_p.add_argument("--host", default=os.environ.get("OLLAMA_HOST", DEFAULT_HOST))
-    run_p.add_argument("--health-file", type=Path, default=Path("monitoring/private-health.json"))
+    run_p.add_argument("--cases", type=Path, default=CASES_FILE)
+    run_p.add_argument("--health-file", type=Path, default=None, help="Optional live snapshot appended as an extra case")
     run_p.add_argument("--output", type=Path, default=OUTPUT_JSONL)
     run_p.add_argument("--models", nargs="+", default=DEFAULT_MODELS)
     run_p.add_argument(
@@ -408,13 +773,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     run_p.add_argument("--num-ctx", type=int, default=8192)
     run_p.add_argument("--timeout", type=int, default=300)
+    run_p.add_argument("--judge-model", default=DEFAULT_JUDGE_MODEL)
+    run_p.add_argument("--judge-samples", type=int, default=3)
+    run_p.add_argument("--judge-timeout", type=int, default=150)
+    run_p.add_argument("--no-judge", action="store_true", help="Deterministic-only run (no cloud judge)")
+    run_p.add_argument("--skip-if-unchanged", action="store_true", help="No-op if fingerprint matches and last run is fresh")
+    run_p.add_argument("--max-stale-days", type=int, default=14, help="Re-run anyway if last real run is older than this")
+    run_p.add_argument("--fingerprint-file", type=Path, default=FINGERPRINT_FILE)
     run_p.set_defaults(func=run_eval)
 
     report_p = sub.add_parser("report", help="Write a rolling evaluation report")
     report_p.add_argument("--input", type=Path, default=OUTPUT_JSONL)
     report_p.add_argument("--output", type=Path, default=OUTPUT_REPORT)
-    report_p.add_argument("--days", type=int, default=7)
+    report_p.add_argument("--days", type=int, default=21)
     report_p.set_defaults(func=report)
+
+    rec_p = sub.add_parser("recommended", help="Print the currently recommended local summary model")
+    rec_p.add_argument("--report", type=Path, default=OUTPUT_REPORT)
+    rec_p.add_argument("--default", default="gemma4:31b-mlx")
+    rec_p.set_defaults(func=lambda a: (print(read_recommended_model(a.report, a.default)) or 0))
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/scripts/ollama-summary-eval
+++ b/scripts/ollama-summary-eval
@@ -349,7 +349,10 @@ def evaluate_deterministic(text: str, exp: dict[str, Any], rows: list[dict[str, 
 
     # 8. no hallucinated repo slug (every owner/name token must be a real input)
     allowed = all_input_names(rows)
-    slugs = {s for s in SLUG_RE.findall(text)}
+    # A real GitHub "owner/name" never has a dot in the owner segment, so a
+    # dotted first segment means a URL/path (github.com/owner, gitlab.com/x) —
+    # not a hallucinated repo slug. Drop those before the membership check.
+    slugs = {s for s in SLUG_RE.findall(text) if "." not in s.split("/", 1)[0]}
     hallucinated = sorted(s for s in slugs if s not in allowed and s.rsplit("/", 1)[-1] not in allowed)
     checks["no_hallucinated_repo"] = not hallucinated
 
@@ -512,7 +515,7 @@ def run_model(host: str, model: str, prompt: str, num_ctx: int, timeout: int) ->
             "tok_s": round(eval_count / (eval_duration / 1e9), 2) if eval_duration else None,
             "summary": text,
         }
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+    except Exception as exc:  # noqa: BLE001 — unattended batch: record the failed model and continue
         return {
             "ok": False,
             "error": repr(exc),
@@ -600,7 +603,10 @@ def run_eval(args: argparse.Namespace) -> int:
 
             det_score = det["det_score"] if det else 0.0
             llm_score = judge["llm_score"] if (judge and judge["ok"]) else None
-            total = round(det_score + llm_score, 3) if llm_score is not None else None
+            # Under --no-judge there is no LLM component, so the deterministic
+            # score IS the total (out of DET_MAX); only treat None as "unscored"
+            # when judging was requested but failed.
+            total = round(det_score + llm_score, 3) if llm_score is not None else (det_score if args.no_judge else None)
 
             record = {
                 "ts": ts,
@@ -617,7 +623,7 @@ def run_eval(args: argparse.Namespace) -> int:
                 "det_score": det_score,
                 "llm_score": llm_score,
                 "total_score": total,
-                "total_max": TOTAL_MAX,
+                "total_max": DET_MAX if args.no_judge else TOTAL_MAX,
             }
             records.append(record)
             with args.output.open("a") as f:

--- a/scripts/private-health-summarize
+++ b/scripts/private-health-summarize
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Summarize private-repo health locally and deliver it to WhatsApp.
+
+This is the PRODUCTION CONSUMER of the ollama-summary-eval benchmark: it picks
+the model the benchmark currently recommends and uses it (locally, via Ollama)
+to turn monitoring/private-health.json into a short RED/YELLOW digest.
+
+Privacy: the input contains private repo names. They are sent ONLY to the LOCAL
+Ollama host and to the operator's own WhatsApp — never to a cloud model. (The
+benchmark that picks the model runs on synthetic golden data, so the cloud judge
+never sees real repo names.) Output goes only to a gitignored file.
+
+The prompt and TSV formatting are imported from scripts/ollama-summary-eval so
+the production summary uses the EXACT format the benchmark scored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import os
+import subprocess
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_eval_module() -> Any:
+    loader = SourceFileLoader("ollama_summary_eval", str(HERE / "ollama-summary-eval"))
+    spec = importlib.util.spec_from_loader("ollama_summary_eval", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def now_local_iso() -> str:
+    return dt.datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def deliver_whatsapp(to: str, text: str, timeout: int = 60) -> bool:
+    try:
+        proc = subprocess.run(
+            ["openclaw", "message", "send", "--channel", "whatsapp", "--target", to, "--message", text],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        print(f"deliver: failed to spawn openclaw ({exc!r})", file=sys.stderr)
+        return False
+    if proc.returncode != 0:
+        print(f"deliver: openclaw exit {proc.returncode}: {proc.stderr.strip()[:200]}", file=sys.stderr)
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    ev = load_eval_module()
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.environ.get("OLLAMA_HOST", ev.DEFAULT_HOST))
+    parser.add_argument("--health-file", type=Path, default=Path("monitoring/private-health.json"))
+    parser.add_argument("--report", type=Path, default=ev.OUTPUT_REPORT)
+    parser.add_argument("--default-model", default="gemma4:31b-mlx")
+    parser.add_argument("--model", default=None, help="Override the model instead of the benchmark recommendation")
+    parser.add_argument("--output", type=Path, default=Path("monitoring/private-health-summary.md"))
+    parser.add_argument("--to", default=os.environ.get("KNISHIOKA_ALERT_TO"))
+    parser.add_argument("--no-deliver", action="store_true")
+    parser.add_argument("--num-ctx", type=int, default=8192)
+    parser.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args(argv)
+
+    if not args.health_file.is_file():
+        print(f"FAILED: missing {args.health_file}", file=sys.stderr)
+        return 1
+    rows = ev.normalize_health_rows(__import__("json").loads(args.health_file.read_text()))
+
+    model = args.model or ev.read_recommended_model(args.report, args.default_model)
+
+    if not rows:
+        summary = "Summary: RED 0 / YELLOW 0 / GREEN 0\nUrgent: なし\nWatch: なし\nStable: 監視対象リポなし\nNext: 監視対象を追加する"
+        seconds = 0.0
+    else:
+        ev.unload_models(args.host, [model])
+        prompt = ev.build_prompt(ev.health_tsv(rows))
+        res = ev.run_model(args.host, model, prompt, args.num_ctx, args.timeout)
+        ev.unload_models(args.host, [model])
+        if not res["ok"]:
+            print(f"FAILED: ollama summarize error: {res['error']}", file=sys.stderr)
+            return 1
+        summary = res["summary"]
+        seconds = res["seconds"]
+
+    exp = ev.expected(rows)
+    counts = exp["counts"]
+    header = f"🩺 Private repo health ({dt.date.today().isoformat()}) — via {model}"
+    body = f"{header}\n\n{summary}"
+
+    # Persist (gitignored — contains private repo names).
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        f"<!-- generated {now_local_iso()} model={model} seconds={seconds} "
+        f"counts={counts} -->\n\n{body}\n"
+    )
+
+    delivered = False
+    if not args.no_deliver:
+        if not args.to:
+            print("deliver: no --to / KNISHIOKA_ALERT_TO set; skipping delivery", file=sys.stderr)
+        else:
+            delivered = deliver_whatsapp(args.to, body)
+
+    print(body)
+    print(f"\n[model={model} counts={counts} delivered={delivered} wrote={args.output}]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/private-repo-collect
+++ b/scripts/private-repo-collect
@@ -87,6 +87,11 @@ def collect_one(repo: str, timeout: int) -> dict[str, Any] | None:
     except subprocess.TimeoutExpired:
         print(f"warn: {repo}: repo-health timed out", file=sys.stderr)
         return None
+    except OSError as exc:
+        # repo-health missing / not executable / unlaunchable — skip this repo
+        # rather than aborting the whole collection loop.
+        print(f"warn: {repo}: failed to execute repo-health ({exc})", file=sys.stderr)
+        return None
     if proc.returncode != 0:
         print(f"warn: {repo}: repo-health exit {proc.returncode}: {proc.stderr.strip()[:160]}", file=sys.stderr)
         return None

--- a/scripts/private-repo-collect
+++ b/scripts/private-repo-collect
@@ -134,6 +134,14 @@ def main(argv: list[str] | None = None) -> int:
     for r in rows:
         counts[r.get("status", "UNKNOWN")] = counts.get(r.get("status", "UNKNOWN"), 0) + 1
     print(f"wrote {args.output}: {len(rows)} repos {counts}" + (f" (failed: {failed})" if failed else ""))
+
+    # A repo we couldn't health-check would otherwise vanish from the summary,
+    # hiding exactly the kind of failure this job exists to surface. Keep the
+    # partial data but exit non-zero so the cron marks the run failed (and the
+    # failure-alert eventually fires) instead of silently reporting all-clear.
+    if failed:
+        print(f"PARTIAL: {len(failed)}/{len(repos)} repos could not be checked: {failed}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/private-repo-collect
+++ b/scripts/private-repo-collect
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Collect private-repo health into monitoring/private-health.json — pure script.
+
+This replaces the multi-step agent loop that the private-repo-check cron used to
+drive. Running scripts/repo-health over each repo and assembling the array needs
+NO LLM intelligence (it is all gh/jq), so doing it in the agent forced a small
+local model to orchestrate ~10 tool calls and it kept failing over to a cloud
+model. Here the whole job is one deterministic command; the cron's agent just
+invokes it and returns DONE, so there is nothing to fall back from.
+
+Output is the FULL nested repo-health schema (status, security.dependabot_alerts,
+ci.last_status, activity.days_inactive, issues.open_count, pull_requests.open_count)
+so private-health-summary can ground its reasons in dependabot/ci.
+
+Privacy: writes only to the gitignored monitoring/private-health.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_pyyaml() -> None:
+    """Re-exec under a PyYAML-capable interpreter if the current one lacks it.
+
+    Cron launches with PATH=/opt/homebrew/bin:... where `python3` is the
+    Homebrew interpreter, which on this host has NO PyYAML — so `import yaml`
+    would crash the job at startup (the same trap ds-pm's cron-watchdog wrapper
+    guards against). /usr/bin/python3 (system) and the mise python both ship
+    PyYAML; fall back to `uv run --with pyyaml` if neither is found.
+    """
+    try:
+        import yaml  # noqa: F401
+        return
+    except ModuleNotFoundError:
+        pass
+    if os.environ.get("_PRC_REEXEC") == "1":
+        sys.exit("FAILED: re-exec interpreter still lacks PyYAML")
+    here = os.path.abspath(__file__)
+    env_flag = {"_PRC_REEXEC": "1"}
+    for cand in ("/usr/bin/python3", "python3.13", "python3.12", "python3.11"):
+        path = cand if os.path.isabs(cand) else shutil.which(cand)
+        if not path or not os.path.exists(path):
+            continue
+        if subprocess.run([path, "-c", "import yaml"], capture_output=True).returncode == 0:
+            os.execve(path, [path, here, *sys.argv[1:]], {**os.environ, **env_flag})
+    uv = shutil.which("uv")
+    if uv:
+        os.execve(uv, [uv, "run", "--with", "pyyaml", "python3", here, *sys.argv[1:]], {**os.environ, **env_flag})
+    sys.exit("FAILED: no PyYAML-capable interpreter found (tried /usr/bin/python3, python3.x, uv)")
+
+
+_ensure_pyyaml()
+import yaml  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+REPO_HEALTH = HERE / "repo-health"
+
+
+def active_private_repos(repos_yaml: Path) -> list[str]:
+    data = yaml.safe_load(repos_yaml.read_text())
+    out = []
+    for r in data.get("private_repos", []):
+        if str(r.get("status", "")).lower() == "on-hold":
+            continue
+        owner, name = r.get("owner"), r.get("name")
+        if owner and name:
+            out.append(f"{owner}/{name}")
+    return out
+
+
+def collect_one(repo: str, timeout: int) -> dict[str, Any] | None:
+    try:
+        proc = subprocess.run(
+            [str(REPO_HEALTH), repo],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"warn: {repo}: repo-health timed out", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        print(f"warn: {repo}: repo-health exit {proc.returncode}: {proc.stderr.strip()[:160]}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"warn: {repo}: bad JSON ({exc})", file=sys.stderr)
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repos", type=Path, default=Path("config/repos.yaml"))
+    p.add_argument("--output", type=Path, default=Path("monitoring/private-health.json"))
+    p.add_argument("--timeout", type=int, default=120, help="Per-repo repo-health timeout (s)")
+    args = p.parse_args(argv)
+
+    repos = active_private_repos(args.repos)
+    if not repos:
+        print("FAILED: no active private repos found", file=sys.stderr)
+        return 1
+
+    rows: list[dict[str, Any]] = []
+    failed: list[str] = []
+    for repo in repos:
+        row = collect_one(repo, args.timeout)
+        if row is None:
+            failed.append(repo)
+        else:
+            rows.append(row)
+
+    if not rows:
+        print(f"FAILED: all {len(repos)} repos failed", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(rows, ensure_ascii=False, indent=2) + "\n")
+
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r.get("status", "UNKNOWN")] = counts.get(r.get("status", "UNKNOWN"), 0) + 1
+    print(f"wrote {args.output}: {len(rows)} repos {counts}" + (f" (failed: {failed})" if failed else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The Ollama-based monitoring cron chain previously measured local model quality but never consumed the result. One job (private-repo-check) was silently falling back to a cloud model, burning ~156k cloud tokens per run. This PR closes the full measure-adopt-verify loop: a rebuilt eval benchmark picks the best local model, a new production consumer uses it locally for private health summaries, data collection is refactored so the small model can actually orchestrate it, and a new token-usage report makes cloud vs. local offload directly observable.

## Related Issue

No linked issue — this is a live-system sync commit (git brought in sync with already-applied cron changes).

## Changes Made

### Added

- `scripts/private-health-summarize` + `private-health-summary` cron (Wed 05:00): production consumer that reads the eval's recommended local model and uses it via Ollama to summarize `private-health.json` into a RED/YELLOW digest, delivered to WhatsApp. Private repo names go only to local Ollama and the operator's own WhatsApp — never to a cloud model.
- `scripts/private-repo-collect`: extracts deterministic data collection (runs `repo-health` over each private repo, assembles JSON) into one standalone script, including a PyYAML re-exec shim to handle Homebrew vs system Python path conflicts in cron.
- `scripts/cron-token-usage` + `monitoring-token-report` cron (Mon 08:00): aggregates `openclaw cron runs` token usage per run, split into CLOUD (paid) vs LOCAL (free/offloaded), delivered to WhatsApp — the instrument that verifies whether jobs actually ran local.
- `scripts/eval-cases/cases.json`: 7 fixed, anonymized golden cases with a difficulty gradient (synthetic repos, safe to send to a cloud judge).

### Changed

- `scripts/ollama-summary-eval` (substantial rewrite):
  - Input switched from the bi-weekly live `private-health.json` to the fixed golden set in `eval-cases/cases.json`.
  - Scoring changed to **hybrid 0-10**: deterministic ground-truth checks (0-6, covering counts, urgent-line/reason grounding, Watch completeness/hygiene, sections, length, hallucinated-repo detection) + cloud LLM judge (0-4, model `openai/gpt-5.4`, different from local candidates to avoid self-grading; per-dimension median over 3 samples).
  - Added **fingerprint gate** (`--skip-if-unchanged` / `--max-stale-days 14`): re-runs only when cases, models, judge model, or scoring version change, or every ~14 days. Eliminates the prior pattern of daily re-summarizing identical frozen input at temp=0.
  - Added `recommended` subcommand for downstream consumption.
  - Added flat/nested health-schema normalization.
- `config/cron/jobs.yaml`: cadence corrections (ollama-summary-eval daily → weekly + fingerprint; review window 7 → 21 days), two new cron job definitions, `private-repo-check` simplified to run `private-repo-collect` and return DONE.
- `.gitignore`: added gitignored runtime outputs (fingerprint cache, health summary, token-usage markdown).

### Fixed

- `private-repo-check` was silently falling back to a cloud model (`gpt-5.x`, ~156k tokens/run) because the multi-step agent tool loop exceeded what the small local model could orchestrate. After refactoring to `private-repo-collect`, verified: `provider=ollama / status=ok / summary=DONE / ~27s / cloud 0 tokens`.
- `--text` flag bug in WhatsApp delivery (should be `--message`) — affected both the health summarizer and the token reporter; both fixed.

## Technical Details

### Implementation Approach

The core design principle is strict privacy partitioning: the golden eval set uses synthetic repo names so it is safe to send to a cloud judge; the production health summarize uses only a local Ollama model so real repo names never leave the machine. The token-usage reporter closes the observability gap by making local vs. cloud spend visible on a weekly basis.

The PyYAML re-exec shim in `private-repo-collect` handles a specific cron environment issue where Homebrew puts a Python binary without PyYAML ahead of `/usr/bin/python3` on PATH — the script detects missing PyYAML and re-execs with the correct interpreter.

### Key Files

- `scripts/ollama-summary-eval` — eval benchmark, hybrid scorer, fingerprint gate, `recommended` subcommand
- `scripts/eval-cases/cases.json` — golden test cases (7 cases, synthetic, safe for cloud judge)
- `scripts/private-health-summarize` — production local-LLM consumer, WhatsApp delivery
- `scripts/private-repo-collect` — deterministic data collection, PyYAML shim
- `scripts/cron-token-usage` — CLOUD vs LOCAL token aggregation, WhatsApp delivery
- `config/cron/jobs.yaml` — cron definitions and cadence corrections

### Privacy Boundary

| Data | Destination |
|---|---|
| Eval golden cases (synthetic repos) | Local Ollama candidates + cloud judge |
| `private-health.json` (real repo names) | Local Ollama only (never cloud) |
| Token usage metrics | Local aggregation + operator's own WhatsApp |

## Test Evidence

All of the following were run against real data during this session:

- **Deterministic scoring**: GOOD summary scored 6.0/6, BAD summary 1.71/6; hallucination correctly caught; tiebreak ground-truth correct.
- **LLM judge**: GOOD summary 3.73/4, BAD summary 0.53/4 (judge correctly penalized wrong urgent repo).
- **E2E eval run** (qwen3.5:4b, 7 cases): hard cases scored 5.3-5.8, easy cases 9.7 — discriminates correctly. `--skip-if-unchanged` confirmed SKIP on re-run.
- **private-health-summarize** on real data: gemma4 produced a grounded RED/YELLOW digest; WhatsApp delivery confirmed after fixing the `--text`/`--message` flag bug.
- **private-repo-check after refactor**: `provider=ollama / status=ok / summary=DONE / ~27s / cloud 0 tokens` (was: gpt-5.x, ~156k cloud tokens).
- **Cron registration**: `verify-cron-playbooks.sh` shows no drift — 9 jobs registered.

Note: gitignored runtime outputs (`private-health.json`, eval `.jsonl`, report `.md` files) are intentionally not committed — they contain private repo names.

## Review Focus

### Critical

- `scripts/ollama-summary-eval` scoring logic (`evaluate_deterministic`, `run_judge`) and the judge prompt — verify the rubric isolates qualitative quality from the already-deterministically-checked facts.
- Privacy boundary — confirm private repo names never reach a cloud model (golden set is synthetic; `private-health-summarize` uses local Ollama only).

### Important

- PyYAML re-exec shim in `scripts/private-repo-collect` — correctness of the interpreter detection and re-exec path.
- `config/cron/jobs.yaml` cadence and job definitions for the two new crons.

### Normal

- `.gitignore` additions for runtime outputs.
- WhatsApp delivery flag fix (`--text` → `--message`) in both new scripts.

## Verification Steps

1. Check out the branch: `git checkout feat/local-llm-monitoring-eval-and-token-report`
2. Run eval against golden set: `scripts/ollama-summary-eval run --models qwen3:4b --judge openai/gpt-5.4`
3. Verify skip: run again immediately — should print SKIP.
4. Check recommended model: `scripts/ollama-summary-eval recommended`
5. Run data collection: `scripts/private-repo-collect`
6. Run health summarizer: `scripts/private-health-summarize`
7. Run token report: `scripts/cron-token-usage`
8. Verify cron registration: `verify-cron-playbooks.sh`

## Deployment Notes

- No environment variable changes required.
- No database migrations.
- Gitignored runtime outputs (`eval fingerprint cache`, `private-health-summary.md`, `token-usage.md`) will be generated on first run.
- Two new cron jobs (`private-health-summary` Wed 05:00, `monitoring-token-report` Mon 08:00) are defined in `jobs.yaml` — register with `openclaw cron register` if not already applied.

## Checklist

- [x] Code follows project patterns
- [x] Self-review completed
- [x] Privacy boundary verified (no real repo names to cloud)
- [x] All scripts tested against real data
- [x] Cron registration verified (no drift)
- [x] Gitignored runtime outputs documented
- [x] WhatsApp delivery confirmed end-to-end