### PR TITLE
feat(cron): PR review-trend pipeline on local Ollama + secrets.env hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ monitoring/ollama-summary-eval.fingerprint.json
 monitoring/cron-token-usage.md
 monitoring/issue-tracker.jsonl
 monitoring/site-qa-history.jsonl
+monitoring/pr-reviews.json
+monitoring/pr-review-summary.md
 
 # Learner context (private)
 config/learner-context.yaml
@@ -71,3 +73,6 @@ tmp/
 
 # Spillover from other workspaces (manual quarantine, move to correct workspace later)
 _di-spillover/
+
+# Local cron build secrets (PII: WhatsApp alert number)
+config/cron/secrets.env

--- a/config/cron/jobs.yaml
+++ b/config/cron/jobs.yaml
@@ -543,3 +543,73 @@ jobs:
       重要（ローカル30Bの暴走防止）:
       - step 2 のあと、追加のツール呼び出し・整形を一切しない。
       - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
+  - name: pr-review-collect
+    description: Collect the reviews on my last-7-day PRs (all orgs) into gitignored JSON
+    schedule:
+      kind: cron
+      # 毎晩 深夜02:30 KUL。mbpローカルollamaが空く深夜帯。収集は gh のみで
+      # LLM不要なので、後段の要約(03:15)の前に確実に終わる。
+      expr: 30 2 * * *
+    thinking: low
+    # 収集は scripts/pr-review-collect が決定論的に全部やる（gh/python のみ・LLM不要）。
+    # @me の全orgのPRに対し reviews/comments エンドポイントを叩くだけなので、
+    # 30B が暴走して cloud にフォールバックする多段ループが無い。
+    timeout_seconds: 900
+    model: ollama/qwen3-coder:30b
+    delivery:
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      PR review collection（収集だけ。要約・配信は後段の pr-review-summary が行う）。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/pr-review-collect --days 7 を実行
+         - gh search prs --author @me --created ">=7日前" で全orgのPRを列挙し、
+           各PRの reviews / inline comments / conversation comments を取得、
+           bot/AI判定して monitoring/pr-reviews.json に集約する
+         - 自分のコメント（返信）は除外。出力は gitignored
+         - git add / commit / push はしない
+      3) python の exit code を見るだけでよい。exit 0 なら成功。
+
+      重要（ローカル30Bの暴走防止）:
+      - step 2 のあと、追加のツール呼び出し・再読み込み・整形を一切しない。
+        自分で gh をループしたり jq/python で組み直したりしてはならない（スクリプトに任せる）。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。
+  - name: pr-review-summary
+    description: Local-model trend summary of reviews on my recent PRs, delivered to WhatsApp
+    schedule:
+      kind: cron
+      # pr-review-collect(02:30) の後に走る。深夜帯でmbpローカルollamaが空いている。
+      expr: 15 3 * * *
+    thinking: low
+    timeout_seconds: 600
+    model: ollama/qwen3-coder:30b
+    delivery:
+      # 配信はスクリプトが openclaw message send で直接行うため none（二重送信回避）。
+      mode: none
+      channel: whatsapp
+      to: "${KNISHIOKA_ALERT_TO}"
+      best_effort: true
+    message: |
+      PR review trend summary（ローカル qwen3-coder → WhatsApp）。
+
+      これは pr-review-collect が集めた monitoring/pr-reviews.json を、ローカル ollama で
+      「レビュー傾向」に要約する出口ジョブ。レビュー本文（業務orgのPRを含む）はローカル
+      ollama と自分の WhatsApp にのみ送る（cloud には一切出さない）。
+
+      手順:
+      1) cd /Users/ken/.openclaw/workspace-knishioka-pm
+      2) python3 scripts/pr-review-summarize --to "${KNISHIOKA_ALERT_TO}" を実行
+         - monitoring/pr-reviews.json を読み、qwen3-coder:30b（keep_alive=0/temp=0）で
+           Top指摘カテゴリ / 活発なAIレビュアー / 繰り返し / Next を生成
+         - WhatsApp 配信 → monitoring/pr-review-summary.md 保存
+         - git add / commit / push はしない
+      3) python の exit code を見るだけでよい。exit 0 なら成功。
+
+      重要（ローカル30Bの暴走防止）:
+      - step 2 のあと、追加のツール呼び出し・再読み込み・整形を一切しない。
+        jq / ruby / python / node で要約を作り直してはならない（配信はスクリプトが済ませている）。
+      - 最後に「DONE」または「FAILED」とだけ一言返して即座に終了する。

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -21,7 +21,7 @@
 
 | パス                               | 役割                                                               | git  |
 | ---------------------------------- | ------------------------------------------------------------------ | ---- |
-| `config/cron/jobs.yaml`            | 宣言的ソース（7 ジョブ）。**編集するのはここだけ**                 | 追跡 |
+| `config/cron/jobs.yaml`            | 宣言的ソース（11 ジョブ）。**編集するのはここだけ**                | 追跡 |
 | `scripts/build-cron-jobs.py`       | jobs.yaml → `build/cron/manifest.json` を生成（message_hash 付き） | 追跡 |
 | `scripts/verify-cron-playbooks.sh` | manifest とライブ登録内容を比較し drift を検出（読み取り専用）     | 追跡 |
 | `scripts/register-cron-jobs.sh`    | manifest をライブに適用。**既存ジョブは id を保ったまま edit**     | 追跡 |
@@ -42,13 +42,32 @@
 | -------------------- | ---------------------------------- | --------------- |
 | `KNISHIOKA_ALERT_TO` | WhatsApp 通知 / failure_alert 宛先 | `+81xxxxxxxxxx` |
 
-```bash
-export KNISHIOKA_ALERT_TO='+81...'   # build / register / verify --live の前に
+**永続化（推奨）**: 値は `config/cron/secrets.env`（**gitignore 済み**）に置く。
+`build-cron-jobs.py` が起動時に自動ロードするので、シェルでの `export` は不要。
+これにより「再ビルドのたびに手で export し忘れ／プレースホルダーを貼って誤登録」
+という事故が起きない（揮発する env への依存を排除）。
+
+```ini
+# config/cron/secrets.env （コミット厳禁）
+KNISHIOKA_ALERT_TO=+81...
 ```
 
-未設定のまま `build` / `register` / `verify --live` を実行すると、`${...}` が未解
-決である旨のエラーで停止する（literal なプレースホルダーを誤登録しない安全装
-置）。`verify --offline` と `build --check` は構造検証のみなので env なしで通る。
+一時的に別宛先で試したいときは `export` が優先される（`os.environ.setdefault`）：
+
+```bash
+export KNISHIOKA_ALERT_TO='+8190...'   # この回だけ secrets.env を上書き
+```
+
+**安全装置（二重）**:
+
+1. 未解決ガード: `${...}` が解決できない（env も secrets.env も無い）まま
+   `build` / `register` / `verify --live` すると、未解決エラーで停止する。
+2. プレースホルダーガード: 解決後の宛先が電話番号/WhatsApp ID の形でない
+   （`+81xxxxxxxxxx` のように英字を含む等）場合も `build` がエラーで停止する。
+   → `+81xxxxxxxxxx` のような literal を二度と黙って登録しない。
+
+`verify --offline` と `build --check` は構造検証のみだが、secrets.env があれば
+そちらも解決する（無くても env なしで通る）。
 
 ## 変更手順（編集 → 生成 → 検証 → commit）
 

--- a/scripts/build-cron-jobs.py
+++ b/scripts/build-cron-jobs.py
@@ -196,9 +196,82 @@ def _normalize_job(
     }
 
 
+def _load_secrets_env(workspace_root: Path) -> None:
+    """Load config/cron/secrets.env into the environment (fills gaps only).
+
+    Secrets / PII (the WhatsApp alert number) must be in os.environ for
+    _expand_env to resolve ${...} references. Relying on the caller to `export`
+    them by hand is fragile: a forgotten or mistyped export silently bakes a
+    placeholder into the live registry (this is exactly how KNISHIOKA_ALERT_TO
+    became '+81xxxxxxxxxx'). Persisting them in this gitignored file makes every
+    build resolve correctly regardless of the shell. An explicit export still
+    wins (setdefault), so a one-off override stays possible.
+    """
+    env_file = workspace_root / "config" / "cron" / "secrets.env"
+    if not env_file.is_file():
+        return
+    for raw in env_file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, val)
+
+
+_PHONE_RE = re.compile(r"^\+?[0-9]{7,15}$")
+_WA_TARGET_SUFFIXES = ("@g.us", "@s.whatsapp.net", "@c.us")
+
+
+def _looks_like_valid_target(to: str) -> bool:
+    local = to
+    for suf in _WA_TARGET_SUFFIXES:
+        if local.endswith(suf):
+            local = local[: -len(suf)]
+            break
+    return bool(_PHONE_RE.match(local))
+
+
+def _validate_targets(jobs: list[dict[str, Any]]) -> None:
+    """Reject resolved delivery targets that look like an unfilled placeholder.
+
+    Guards the failure mode where ${KNISHIOKA_ALERT_TO} resolves to a docs
+    placeholder like '+81xxxxxxxxxx' (which IS set, so the unset-env check below
+    misses it) and gets silently registered. Only fully-resolved values are
+    checked; literals still containing '${' are caught by the unresolved-env
+    gate instead.
+    """
+    bad: list[str] = []
+    for job in jobs:
+        candidates: list[tuple[str, str]] = []
+        delivery = job.get("delivery") or {}
+        if delivery.get("to"):
+            candidates.append(("delivery.to", delivery["to"]))
+        fa = job.get("failure_alert") or {}
+        if fa.get("to"):
+            candidates.append(("failure_alert.to", fa["to"]))
+        for where, val in candidates:
+            if "${" in val:
+                continue
+            if not _looks_like_valid_target(val):
+                bad.append(f"{job.get('name')}: {where}={val!r}")
+    if bad:
+        joined = "\n  ".join(bad)
+        raise SystemExit(
+            "build-cron-jobs: delivery target(s) look like an unfilled "
+            "placeholder, not a real phone/WhatsApp id:\n  "
+            f"{joined}\n"
+            "  Fix config/cron/secrets.env (e.g. KNISHIOKA_ALERT_TO=+<digits>) "
+            "and rebuild. A real number must be all digits (optionally +-prefixed)."
+        )
+
+
 def build(
     workspace_root: Path, jobs_yaml_path: Path, allow_unset_env: bool = False
 ) -> dict[str, Any]:
+    _load_secrets_env(workspace_root)
     spec = _load_yaml(jobs_yaml_path)
     if spec.get("schema_version") != 1:
         raise SystemExit(
@@ -262,6 +335,9 @@ def build(
     dups = sorted(name for name, count in seen.items() if count > 1)
     if dups:
         raise SystemExit(f"build-cron-jobs: duplicate job names produced: {dups}")
+
+    # Reject placeholder-looking delivery targets before they reach the registry.
+    _validate_targets(expanded)
 
     try:
         generated_from = str(jobs_yaml_path.relative_to(workspace_root))

--- a/scripts/build-cron-jobs.py
+++ b/scripts/build-cron-jobs.py
@@ -222,16 +222,18 @@ def _load_secrets_env(workspace_root: Path) -> None:
 
 
 _PHONE_RE = re.compile(r"^\+?[0-9]{7,15}$")
+# WhatsApp JIDs / group IDs are long digit strings (group IDs are ~18 digits and
+# can carry a legacy "<creator>-<timestamp>" hyphen), and are NOT length-bounded
+# like phone numbers — so they get their own pattern rather than _PHONE_RE.
+_WA_JID_LOCAL_RE = re.compile(r"^[0-9][0-9-]{4,29}$")
 _WA_TARGET_SUFFIXES = ("@g.us", "@s.whatsapp.net", "@c.us")
 
 
 def _looks_like_valid_target(to: str) -> bool:
-    local = to
     for suf in _WA_TARGET_SUFFIXES:
-        if local.endswith(suf):
-            local = local[: -len(suf)]
-            break
-    return bool(_PHONE_RE.match(local))
+        if to.endswith(suf):
+            return bool(_WA_JID_LOCAL_RE.match(to[: -len(suf)]))
+    return bool(_PHONE_RE.match(to))
 
 
 def _validate_targets(jobs: list[dict[str, Any]]) -> None:
@@ -253,9 +255,10 @@ def _validate_targets(jobs: list[dict[str, Any]]) -> None:
         if fa.get("to"):
             candidates.append(("failure_alert.to", fa["to"]))
         for where, val in candidates:
-            if "${" in val:
+            sval = str(val)
+            if "${" in sval:
                 continue
-            if not _looks_like_valid_target(val):
+            if not _looks_like_valid_target(sval):
                 bad.append(f"{job.get('name')}: {where}={val!r}")
     if bad:
         joined = "\n  ".join(bad)

--- a/scripts/pr-review-collect
+++ b/scripts/pr-review-collect
@@ -73,9 +73,26 @@ def run_gh_json(args: list[str], timeout: int = 60) -> Any:
         return None
     try:
         return json.loads(out)
-    except json.JSONDecodeError as exc:
-        print(f"gh: bad JSON for {args[:3]}: {exc}", file=sys.stderr)
-        return None
+    except json.JSONDecodeError:
+        # `gh api --paginate` concatenates one JSON array per page (e.g.
+        # "[...][...]"), which is not a single valid document. Stitch the pages
+        # back together with a raw_decode loop instead of silently dropping
+        # everything past the first page.
+        decoder = json.JSONDecoder()
+        merged: list[Any] = []
+        idx, length = 0, len(out)
+        try:
+            while idx < length:
+                while idx < length and out[idx].isspace():
+                    idx += 1
+                if idx >= length:
+                    break
+                obj, idx = decoder.raw_decode(out, idx)
+                merged.extend(obj) if isinstance(obj, list) else merged.append(obj)
+            return merged
+        except json.JSONDecodeError as exc:
+            print(f"gh: bad JSON for {args[:3]}: {exc}", file=sys.stderr)
+            return None
 
 
 def classify(login: str) -> dict[str, bool]:
@@ -168,10 +185,10 @@ def main(argv: list[str] | None = None) -> int:
         pr_records.append({
             "repo": nameWithOwner,
             "number": number,
-            "title": pr.get("title", ""),
-            "url": pr.get("url", ""),
-            "created_at": pr.get("createdAt", ""),
-            "state": pr.get("state", ""),
+            "title": pr.get("title") or "",
+            "url": pr.get("url") or "",
+            "created_at": pr.get("createdAt") or "",
+            "state": pr.get("state") or "",
             "is_draft": pr.get("isDraft", False),
             "feedback": items,
         })

--- a/scripts/pr-review-collect
+++ b/scripts/pr-review-collect
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Collect the reviews landing on MY recent PRs into monitoring/pr-reviews.json.
+
+Phase 1 of the pr-review-trend pipeline (the summary/delivery is phase 2,
+scripts/pr-review-summarize). This is the DETERMINISTIC collector: it is pure
+`gh` + python with NO LLM, mirroring scripts/private-repo-collect.
+
+Why a script and not an agent loop: gathering N PRs x 3 review endpoints is
+~150 `gh api` calls of plain orchestration with zero reasoning. Driving that
+from a small local model (qwen3-coder:30b) forces a long tool loop that the 30B
+cannot sustain and it falls over to a cloud model (billed). Here the whole walk
+is one command; the cron agent just runs it and returns DONE.
+
+What it gathers, for every PR `@me` authored in the last N days, across ALL orgs:
+  - formal reviews            (gh api .../pulls/{n}/reviews)         APPROVE / CHANGES_REQUESTED / COMMENT + body
+  - inline review comments     (gh api .../pulls/{n}/comments)        per-file line comments
+  - PR conversation comments   (gh api .../issues/{n}/comments)       where bots like CodeRabbit post their digest
+Self-authored items are dropped (those are my own replies, not reviews received).
+Each reviewer is tagged is_bot / is_ai so phase 2 can analyse AI-review trends.
+
+Privacy: PRs span work orgs (D-stats, datainformed-jp). The review text is
+written ONLY to the gitignored monitoring/pr-reviews.json and, in phase 2, sent
+ONLY to the LOCAL Ollama host + the operator's own WhatsApp — never to a cloud
+model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Bot logins whose reviews are AI code review, not CI/automation noise. Matched
+# case-insensitively against the login with any trailing "[bot]" stripped.
+AI_REVIEWER_LOGINS = {
+    "copilot",
+    "copilot-pull-request-reviewer",
+    "coderabbitai",
+    "codex",
+    "chatgpt-codex-connector",
+    "sourcery-ai",
+    "sweep-ai",
+    "ellipsis-dev",
+    "gemini-code-assist",
+    "cursor",
+    "greptile-apps",
+    "qodo-merge-pro",
+    "codeant-ai",
+}
+# Body truncation so one chatty bot digest cannot dominate the phase-2 prompt.
+MAX_BODY_CHARS = 800
+
+
+def run_gh_json(args: list[str], timeout: int = 60) -> Any:
+    """Run a `gh` command expected to emit JSON; return parsed value or None."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, timeout=timeout
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        print(f"gh: failed to run {args[:2]}: {exc!r}", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        # 404 (e.g. PR moved) / transient: log and skip, never abort the batch.
+        print(f"gh: exit {proc.returncode} for {args[:3]}: {proc.stderr.strip()[:160]}", file=sys.stderr)
+        return None
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        print(f"gh: bad JSON for {args[:3]}: {exc}", file=sys.stderr)
+        return None
+
+
+def classify(login: str) -> dict[str, bool]:
+    base = login.lower()
+    is_bot = base.endswith("[bot]")
+    if is_bot:
+        base = base[: -len("[bot]")]
+    return {"is_bot": is_bot, "is_ai": base in AI_REVIEWER_LOGINS}
+
+
+def trunc(text: str | None) -> str:
+    text = (text or "").strip()
+    return text if len(text) <= MAX_BODY_CHARS else text[:MAX_BODY_CHARS] + " …[truncated]"
+
+
+def collect_feedback(owner: str, repo: str, number: int, me: str) -> list[dict[str, Any]]:
+    """Return all non-self review feedback items on one PR."""
+    items: list[dict[str, Any]] = []
+
+    def add(login: str | None, kind: str, body: str | None, state: str | None = None, path: str | None = None) -> None:
+        login = login or "unknown"
+        if login.lower() == me.lower():
+            return  # my own reply, not a review I received
+        body = trunc(body)
+        if not body and not state:
+            return
+        rec = {"author": login, "kind": kind, "body": body, **classify(login)}
+        if state:
+            rec["state"] = state
+        if path:
+            rec["path"] = path
+        items.append(rec)
+
+    base = f"repos/{owner}/{repo}"
+    for rev in run_gh_json(["api", f"{base}/pulls/{number}/reviews", "--paginate"]) or []:
+        add((rev.get("user") or {}).get("login"), "review", rev.get("body"), state=rev.get("state"))
+    for c in run_gh_json(["api", f"{base}/pulls/{number}/comments", "--paginate"]) or []:
+        add((c.get("user") or {}).get("login"), "inline", c.get("body"), path=c.get("path"))
+    for c in run_gh_json(["api", f"{base}/issues/{number}/comments", "--paginate"]) or []:
+        add((c.get("user") or {}).get("login"), "comment", c.get("body"))
+    return items
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=7, help="look back this many days")
+    parser.add_argument("--author", default="@me")
+    parser.add_argument("--limit", type=int, default=100, help="max PRs from gh search")
+    parser.add_argument("--output", type=Path, default=Path("monitoring/pr-reviews.json"))
+    args = parser.parse_args(argv)
+
+    # `gh api user -q` returns a bare string, not JSON — fetch plainly.
+    try:
+        me = subprocess.run(["gh", "api", "user", "-q", ".login"], capture_output=True, text=True, timeout=30).stdout.strip()
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAILED: cannot resolve gh login: {exc!r}", file=sys.stderr)
+        return 1
+    if not me:
+        print("FAILED: empty gh login", file=sys.stderr)
+        return 1
+
+    since = (dt.datetime.now().astimezone() - dt.timedelta(days=args.days)).date().isoformat()
+    prs = run_gh_json([
+        "search", "prs",
+        "--author", args.author,
+        "--created", f">={since}",
+        "--json", "number,title,repository,createdAt,url,state,isDraft",
+        "--limit", str(args.limit),
+    ])
+    if prs is None:
+        print("FAILED: gh search prs returned nothing", file=sys.stderr)
+        return 1
+
+    pr_records: list[dict[str, Any]] = []
+    reviewer_counts: dict[str, int] = {}
+    ai_reviewer_counts: dict[str, int] = {}
+    total_items = 0
+    for pr in prs:
+        nameWithOwner = (pr.get("repository") or {}).get("nameWithOwner") or ""
+        if "/" not in nameWithOwner:
+            continue
+        owner, repo = nameWithOwner.split("/", 1)
+        number = pr["number"]
+        items = collect_feedback(owner, repo, number, me)
+        for it in items:
+            reviewer_counts[it["author"]] = reviewer_counts.get(it["author"], 0) + 1
+            if it["is_ai"]:
+                ai_reviewer_counts[it["author"]] = ai_reviewer_counts.get(it["author"], 0) + 1
+        total_items += len(items)
+        pr_records.append({
+            "repo": nameWithOwner,
+            "number": number,
+            "title": pr.get("title", ""),
+            "url": pr.get("url", ""),
+            "created_at": pr.get("createdAt", ""),
+            "state": pr.get("state", ""),
+            "is_draft": pr.get("isDraft", False),
+            "feedback": items,
+        })
+        print(f"  {nameWithOwner}#{number}: {len(items)} review item(s)", file=sys.stderr)
+
+    reviewed = sum(1 for r in pr_records if r["feedback"])
+    payload = {
+        "generated_at": dt.datetime.now().astimezone().isoformat(timespec="seconds"),
+        "author": me,
+        "window_days": args.days,
+        "since": since,
+        "totals": {
+            "prs": len(pr_records),
+            "prs_with_reviews": reviewed,
+            "review_items": total_items,
+            "reviewers": dict(sorted(reviewer_counts.items(), key=lambda kv: -kv[1])),
+            "ai_reviewers": dict(sorted(ai_reviewer_counts.items(), key=lambda kv: -kv[1])),
+        },
+        "prs": pr_records,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    print(
+        f"DONE: {len(pr_records)} PRs ({reviewed} reviewed), {total_items} review items, "
+        f"{len(ai_reviewer_counts)} AI reviewer(s) → {args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-review-summarize
+++ b/scripts/pr-review-summarize
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Summarize PR-review TRENDS locally (Ollama) and deliver to WhatsApp.
+
+Phase 2 of the pr-review-trend pipeline. Reads the gitignored
+monitoring/pr-reviews.json produced by scripts/pr-review-collect, feeds an
+aggregated digest to the LOCAL Ollama model in ONE chat call, and turns it into
+a short Japanese trend report: what kinds of feedback the AI reviewers keep
+raising on my PRs this week.
+
+Design (same guardrails as scripts/private-health-summarize):
+  - ONE generate call. The script owns all formatting/truncation so the 30B
+    never has to orchestrate; the cron agent just runs this and returns DONE.
+  - keep_alive=0 unload before & after, temperature=0 → deterministic.
+  - Runs deep at night when the mbp Ollama host is idle.
+
+Privacy: review text (incl. work-org PRs) goes ONLY to the LOCAL Ollama host and
+the operator's own WhatsApp. Output md is gitignored. Nothing reaches a cloud
+model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+# Reuse the eval module's Ollama plumbing (host default, unload, post_json).
+_loader = SourceFileLoader("ollama_summary_eval", str(HERE / "ollama-summary-eval"))
+_spec = importlib.util.spec_from_loader("ollama_summary_eval", _loader)
+ev = importlib.util.module_from_spec(_spec)
+_loader.exec_module(ev)
+
+# Total review-text budget fed to the model. Big enough for a week of AI
+# reviews, small enough to stay well inside num_ctx with the instructions.
+MAX_DIGEST_CHARS = 24000
+
+
+def now_local_iso() -> str:
+    return dt.datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def build_digest(data: dict[str, Any]) -> str:
+    """Flatten the collected reviews into a compact text digest for the model."""
+    lines: list[str] = []
+    t = data.get("totals", {})
+    lines.append(
+        f"集計: PR {t.get('prs', 0)}件 / レビュー付き {t.get('prs_with_reviews', 0)}件 / "
+        f"レビュー項目 {t.get('review_items', 0)}件 (直近{data.get('window_days', 7)}日)"
+    )
+    ai = t.get("ai_reviewers", {})
+    if ai:
+        lines.append("AIレビュアー件数: " + ", ".join(f"{k}={v}" for k, v in ai.items()))
+    lines.append("")
+    for pr in data.get("prs", []):
+        fb = pr.get("feedback", [])
+        if not fb:
+            continue
+        lines.append(f"## {pr['repo']}#{pr['number']} {pr.get('title', '')}".rstrip())
+        for it in fb:
+            tag = "AI" if it.get("is_ai") else ("bot" if it.get("is_bot") else "human")
+            head = f"- [{tag}:{it['author']}/{it['kind']}"
+            if it.get("state"):
+                head += f"/{it['state']}"
+            if it.get("path"):
+                head += f" {it['path']}"
+            head += "]"
+            body = (it.get("body") or "").replace("\n", " ").strip()
+            lines.append(f"{head} {body}".rstrip())
+        lines.append("")
+    digest = "\n".join(lines)
+    if len(digest) > MAX_DIGEST_CHARS:
+        digest = digest[:MAX_DIGEST_CHARS] + "\n…[digest truncated]"
+    return digest
+
+
+def build_prompt(digest: str) -> str:
+    return (
+        "あなたは開発レビューのアナリストです。以下は、ある開発者が直近1週間で作成した"
+        "プルリクエストに届いたレビュー(AI/bot/人間)の一覧です。これを読み、レビューの"
+        "『傾向』を日本語で簡潔に分析してください。個々のPRの説明ではなく、横断した傾向を"
+        "抽出すること。\n\n"
+        "次のフォーマットで、各項目1-3行・合計15行以内で出力:\n"
+        "Top指摘カテゴリ: (例: テスト不足 / エラーハンドリング / 型付け / 命名 など多い順に3-5個、各々おおよその件数や該当領域)\n"
+        "活発なAIレビュアー: (どのbotがどんな指摘を多くしているか)\n"
+        "繰り返し: (複数PRで再発している同種の指摘があれば)\n"
+        "Next: (来週意識すると指摘を減らせる具体アクション1-2個)\n\n"
+        "余計な前置き・後書きは書かない。日本語で。\n\n"
+        f"=== レビュー一覧 ===\n{digest}\n"
+    )
+
+
+def run_ollama(host: str, model: str, prompt: str, num_ctx: int, num_predict: int, timeout: int) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "think": False,
+        "keep_alive": "0",
+        "options": {"temperature": 0, "num_ctx": num_ctx, "num_predict": num_predict},
+    }
+    started = time.time()
+    try:
+        body = ev.post_json(host, "/api/chat", payload, timeout)
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": repr(exc), "seconds": round(time.time() - started, 2), "summary": ""}
+    text = ((body.get("message") or {}).get("content") or "").strip()
+    return {
+        "ok": bool(text),
+        "error": None if text else "empty_response",
+        "seconds": round(time.time() - started, 2),
+        "summary": text,
+    }
+
+
+def deliver_whatsapp(to: str, text: str, timeout: int = 60) -> bool:
+    try:
+        proc = subprocess.run(
+            ["openclaw", "message", "send", "--channel", "whatsapp", "--target", to, "--message", text],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        print(f"deliver: failed to spawn openclaw ({exc!r})", file=sys.stderr)
+        return False
+    if proc.returncode != 0:
+        print(f"deliver: openclaw exit {proc.returncode}: {proc.stderr.strip()[:200]}", file=sys.stderr)
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.environ.get("OLLAMA_HOST", ev.DEFAULT_HOST))
+    parser.add_argument("--input", type=Path, default=Path("monitoring/pr-reviews.json"))
+    parser.add_argument("--output", type=Path, default=Path("monitoring/pr-review-summary.md"))
+    parser.add_argument("--model", default="qwen3-coder:30b")
+    parser.add_argument("--num-ctx", type=int, default=16384)
+    parser.add_argument("--num-predict", type=int, default=700)
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--to", default=os.environ.get("KNISHIOKA_ALERT_TO"))
+    parser.add_argument("--no-deliver", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.input.is_file():
+        print(f"FAILED: missing {args.input} (run scripts/pr-review-collect first)", file=sys.stderr)
+        return 1
+    data = json.loads(args.input.read_text())
+    t = data.get("totals", {})
+
+    if not t.get("review_items"):
+        summary = (
+            "Top指摘カテゴリ: 直近のレビュー項目なし\n"
+            "活発なAIレビュアー: なし\n"
+            "繰り返し: なし\n"
+            "Next: レビューがまだ付いていない。マージ前にAIレビュー設定を確認する"
+        )
+        seconds = 0.0
+    else:
+        ev.unload_models(args.host, [args.model])
+        res = run_ollama(args.host, args.model, build_prompt(build_digest(data)), args.num_ctx, args.num_predict, args.timeout)
+        ev.unload_models(args.host, [args.model])
+        if not res["ok"]:
+            print(f"FAILED: ollama error: {res['error']}", file=sys.stderr)
+            return 1
+        summary = res["summary"]
+        seconds = res["seconds"]
+
+    header = (
+        f"🔎 PRレビュー傾向 ({dt.date.today().isoformat()}, 直近{data.get('window_days', 7)}日) — via {args.model}\n"
+        f"PR {t.get('prs', 0)}件 / レビュー付き {t.get('prs_with_reviews', 0)}件 / 項目 {t.get('review_items', 0)}件"
+    )
+    body = f"{header}\n\n{summary}"
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        f"<!-- generated {now_local_iso()} model={args.model} seconds={seconds} "
+        f"prs={t.get('prs', 0)} items={t.get('review_items', 0)} -->\n\n{body}\n"
+    )
+
+    delivered = False
+    if not args.no_deliver:
+        if not args.to:
+            print("deliver: no --to / KNISHIOKA_ALERT_TO set; skipping delivery", file=sys.stderr)
+        else:
+            delivered = deliver_whatsapp(args.to, body)
+
+    print(body)
+    print(f"\n[model={args.model} seconds={seconds} delivered={delivered} wrote={args.output}]")
+    print("DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-review-summarize
+++ b/scripts/pr-review-summarize
@@ -51,12 +51,12 @@ def now_local_iso() -> str:
 def build_digest(data: dict[str, Any]) -> str:
     """Flatten the collected reviews into a compact text digest for the model."""
     lines: list[str] = []
-    t = data.get("totals", {})
+    t = data.get("totals") or {}
     lines.append(
-        f"集計: PR {t.get('prs', 0)}件 / レビュー付き {t.get('prs_with_reviews', 0)}件 / "
-        f"レビュー項目 {t.get('review_items', 0)}件 (直近{data.get('window_days', 7)}日)"
+        f"集計: PR {t.get('prs') or 0}件 / レビュー付き {t.get('prs_with_reviews') or 0}件 / "
+        f"レビュー項目 {t.get('review_items') or 0}件 (直近{data.get('window_days') or 7}日)"
     )
-    ai = t.get("ai_reviewers", {})
+    ai = t.get("ai_reviewers") or {}
     if ai:
         lines.append("AIレビュアー件数: " + ", ".join(f"{k}={v}" for k, v in ai.items()))
     lines.append("")
@@ -64,7 +64,7 @@ def build_digest(data: dict[str, Any]) -> str:
         fb = pr.get("feedback", [])
         if not fb:
             continue
-        lines.append(f"## {pr['repo']}#{pr['number']} {pr.get('title', '')}".rstrip())
+        lines.append(f"## {pr['repo']}#{pr['number']} {pr.get('title') or ''}".rstrip())
         for it in fb:
             tag = "AI" if it.get("is_ai") else ("bot" if it.get("is_bot") else "human")
             head = f"- [{tag}:{it['author']}/{it['kind']}"
@@ -153,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAILED: missing {args.input} (run scripts/pr-review-collect first)", file=sys.stderr)
         return 1
     data = json.loads(args.input.read_text())
-    t = data.get("totals", {})
+    t = data.get("totals") or {}
 
     if not t.get("review_items"):
         summary = (
@@ -174,15 +174,15 @@ def main(argv: list[str] | None = None) -> int:
         seconds = res["seconds"]
 
     header = (
-        f"🔎 PRレビュー傾向 ({dt.date.today().isoformat()}, 直近{data.get('window_days', 7)}日) — via {args.model}\n"
-        f"PR {t.get('prs', 0)}件 / レビュー付き {t.get('prs_with_reviews', 0)}件 / 項目 {t.get('review_items', 0)}件"
+        f"🔎 PRレビュー傾向 ({dt.date.today().isoformat()}, 直近{data.get('window_days') or 7}日) — via {args.model}\n"
+        f"PR {t.get('prs') or 0}件 / レビュー付き {t.get('prs_with_reviews') or 0}件 / 項目 {t.get('review_items') or 0}件"
     )
     body = f"{header}\n\n{summary}"
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
         f"<!-- generated {now_local_iso()} model={args.model} seconds={seconds} "
-        f"prs={t.get('prs', 0)} items={t.get('review_items', 0)} -->\n\n{body}\n"
+        f"prs={t.get('prs') or 0} items={t.get('review_items') or 0} -->\n\n{body}\n"
     )
 
     delivered = False


### PR DESCRIPTION
## Summary

Adds a two-phase nightly pipeline that collects and summarises the reviews landing on my recent PRs, run entirely on the local mbp Ollama (`qwen3-coder:30b`) — no review text ever reaches a cloud model. Also fixes a latent secret-resolution bug that was silently baking the docs placeholder `+81xxxxxxxxxx` into the live cron registry, breaking WhatsApp delivery.

6 files changed: +583 lines, -5 lines (2 new scripts, 2 modified, 1 YAML, 1 gitignore update).

## Changes Made

### Added

- `scripts/pr-review-collect` — deterministic `gh`/Python collector (no LLM). Iterates `@me` PRs from the last 7 days across all orgs, fetches formal reviews, inline comments, and PR conversation comments (where bots like CodeRabbit post their digest). Drops self-authored items. Tags each reviewer with `is_bot` / `is_ai` using a curated `AI_REVIEWER_LOGINS` set (copilot, coderabbitai, codex, gemini-code-assist, sourcery-ai, etc.). Writes to the gitignored `monitoring/pr-reviews.json`. The whole walk is one command so the cron agent returns `DONE` immediately — no 30B tool loop, no cloud fallback.
- `scripts/pr-review-summarize` — reads the collected JSON, truncates chatty bot bodies to avoid prompt domination, makes a single `ollama.chat` call (`qwen3-coder:30b`, `temperature=0`, `keep_alive=0`) to produce a Japanese trend report (top feedback categories, most active AI reviewers, recurring asks, next actions), delivers to WhatsApp via `openclaw message send`, and writes `monitoring/pr-review-summary.md`.

### Changed

- `config/cron/jobs.yaml` — two new daily jobs: `pr-review-collect` at 02:30 KUL and `pr-review-summary` at 03:15 KUL, both `model: ollama/qwen3-coder:30b`. Each job message ends with the `DONE/FAILED` guard to prevent the 30B from looping. Job count 7 → 11 (two jobs here + two from the previous private-repo offload in the same file version).
- `scripts/build-cron-jobs.py` — two hardening additions:
  - `_load_secrets_env()`: auto-loads `config/cron/secrets.env` (gitignored) at build time using `os.environ.setdefault` so `${KNISHIOKA_ALERT_TO}` resolves without a manual `export`; an explicit shell export still wins.
  - `_validate_targets()`: rejects any fully-resolved delivery `to` value that does not match `^\+?[0-9]{7,15}$` or a WhatsApp group suffix (`@g.us`, `@s.whatsapp.net`, `@c.us`). Called after env expansion, before the registry write. Build exits non-zero on failure.
- `docs/cron.md` — documents the `secrets.env` convention and the two-layer guard (auto-load + placeholder rejection); job count reference updated 7 → 11.
- `.gitignore` — adds `config/cron/secrets.env`, `monitoring/pr-reviews.json`, `monitoring/pr-review-summary.md`.

## Review Focus

### Critical

- **Privacy boundary** — work-org review text flows only to the local Ollama host and the operator's own WhatsApp. Output files are gitignored. Confirm nothing in `pr-review-collect` or `pr-review-summarize` sends data to a remote service beyond those two endpoints.
- **Placeholder-rejection regex** in `build-cron-jobs.py` (`_PHONE_RE = re.compile(r"^\+?[0-9]{7,15}$")` + `_WA_TARGET_SUFFIXES`): should accept real phone numbers and WhatsApp group IDs (`...@g.us`) while rejecting `+81xxxxxxxxxx`. The strip-suffix-then-match approach is worth a close read.

### Important

- **Bot/AI classification** in `pr-review-collect` (`AI_REVIEWER_LOGINS` set): verify the list covers the bots active in the target orgs and that the `[bot]` suffix stripping matches GitHub's actual login format.
- **Single-command design** in both scripts: the cron message instructs the 30B to run one command and return `DONE`. Confirm there are no exit paths in either script that could stall or produce partial output that would invite a follow-up tool call from the agent.
- **`setdefault` ordering** in `_load_secrets_env()`: file values must not override an already-exported shell variable. Verify `setdefault` is called before any `os.environ[]` assignment that might happen later in the build.

### Normal

- `docs/cron.md` accuracy — job count and secrets.env instructions match actual YAML.
- `.gitignore` entries cover all pipeline output files.

## Verification

Tested locally end-to-end before this PR:

- `pr-review-collect`: 100 PRs / 468 review items collected successfully.
- `pr-review-summarize`: ~19 s pure-Ollama generation; sample output showed gemini 299 / codex 111 review items.
- `build-cron-jobs.py` resolves `KNISHIOKA_ALERT_TO` from `secrets.env` in a clean shell with no prior `export`.
- Build exits non-zero when `to` contains the docs placeholder.
- `verify-cron-playbooks.sh --live` reports no drift: 11 jobs registered, 11 match.

## Verification Steps

1. `git checkout feat/pr-review-trend-cron`
2. Create `config/cron/secrets.env` with `KNISHIOKA_ALERT_TO=+<real-number>` and verify `python3 scripts/build-cron-jobs.py` succeeds.
3. Set `KNISHIOKA_ALERT_TO=+81xxxxxxxxxx` in env (or write it to secrets.env) and verify the build exits non-zero with the placeholder rejection message.
4. Run `python3 scripts/pr-review-collect --days 7 --dry-run` (if dry-run flag present) or against a personal org to check JSON output shape.
5. Confirm `monitoring/pr-reviews.json` and `monitoring/pr-review-summary.md` appear in `.gitignore` (`git check-ignore -v monitoring/pr-reviews.json`).

## Checklist

- [x] Code follows project patterns (mirrors private-repo-collect / private-health-summarize offload)
- [x] Self-review completed
- [x] Output files gitignored; no PII in tracked files
- [x] `secrets.env` gitignored
- [x] Both scripts tested end-to-end locally
- [x] Build guard tested (placeholder rejection exits non-zero)
- [x] `verify-cron-playbooks.sh --live` passes (11/11)
- [x] docs/cron.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)